### PR TITLE
Add userId reference field import if schema belongs to user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/src/commands/generate/generators/model.ts
+++ b/src/commands/generate/generators/model.ts
@@ -169,9 +169,12 @@ function generateModelContent(schema: Schema, dbType: DBType) {
 
   const uniqueTypes = Array.from(new Set(usedTypes));
   const importStatement = `import { ${uniqueTypes
-    .join(", ")
     .concat(
-      `, ${config.tableFunc}`
+      schema.belongsToUser ? [getReferenceFieldType("string")[dbType]] : []
+    )
+    .concat(config.tableFunc)
+    .join(
+      ", "
     )} } from "drizzle-orm/${dbType}-core";\nimport { createInsertSchema, createSelectSchema } from "drizzle-zod";\nimport { z } from "zod";\n${
     referenceImports.length > 0 ? referenceImports.join("\n") : ""
   }${schema.belongsToUser ? '\nimport { users } from "./auth";' : ""}`;


### PR DESCRIPTION
I added a simple fix for issue #2 by concatenating the userId reference field type when the schema belongs to a user.

Note: I used "string" reference field type because the [generated users table](https://github.com/nicoalbanese/kirimase/blob/6e84314ebafa6f3a822b2ad6638843c4f0c02af6/src/commands/add/next-auth/generators.ts#L98) always uses text or varchar.