### PR TITLE
fix(runCommand): Filter out empty string arguments

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -88,11 +88,12 @@ export function createFolder(relativePath: string) {
 // }
 
 export const runCommand = async (command: string, args: string[]) => {
+  const formattedArgs = args.filter((a) => a !== "");
   try {
-    await execa(command, args, { stdio: "inherit" });
+    await execa(command, formattedArgs, { stdio: "inherit" });
   } catch (error) {
     throw new Error(
-      `command "${command} ${args.join(" ")}" exited with code ${error.code}`
+      `command "${command} ${formattedArgs.join(" ").trim()}" exited with code ${error.code}`
     );
   }
 };


### PR DESCRIPTION
Resolves an issue in `runCommand` where `execa` treated empty string arguments as literal arguments, causing commands like `bun add` to fail. This change filters out any explicit empty string arguments to avoid this behavior.

Related Issue: https://github.com/nicoalbanese/kirimase/issues/18