### PR TITLE
Bug: fixed template literal bug in tRPC template

### DIFF
--- a/src/commands/add/misc/trpc/generators.ts
+++ b/src/commands/add/misc/trpc/generators.ts
@@ -214,7 +214,7 @@ export type Context = Awaited<ReturnType<typeof createContext>>;
 export const libTrpcUtilsTs = () => {
   return `function getBaseUrl() {
   if (typeof window !== "undefined") return "";
-  if (process.env.VERCEL_URL) return \`https://${process.env.VERCEL_URL}\`;
+  if (process.env.VERCEL_URL) return \`https://\${process.env.VERCEL_URL}\`;
   return "http://localhost:3000";
 }
 


### PR DESCRIPTION
inside the `libTrpcUtilsTs` the template literal that was suppose to be part of the template itself wasn't escaped properly resulting a creation of a bad URL (https://undefined).

I escaped the $ sign so it will be part of the string of the template. 