### PR TITLE
Command `bunx` may cause issues

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -136,7 +136,7 @@ export const pmInstallCommand = {
   pnpm: "pnpm",
   npm: "npx",
   yarn: "npx",
-  bun: "bunx",
+  bun: "bun x",
 };
 
 export async function installShadcnUIComponents(


### PR DESCRIPTION
Hey,
As it is seen in [this issue](https://github.com/oven-sh/bun/issues/4598) `bunx` command can cause errors for some people so I've changed it to `bun x`.
 It _should_ not break anything because `bunx` is just an [alias](https://bun.sh/docs/cli/bunx) for `bun x`.