### PR TITLE
Run init with CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,15 +123,16 @@ You can run Kirimase entirely via the command line as follows:
 kirimase init -sf yes -pm pnpm --orm prisma -db pg -a next-auth -ap github discord -ie yes
 ```
 
-| Command | Short Flag | Long Option            | Description                               | Argument   |
-|---------|------------|------------------------|-------------------------------------------|------------|
-| init    | -          | -                      | initialise and configure kirimase         | -          |
-| -       | -sf        | --src-folder           | use a src folder                          | -          |
-| -       | -pm        | --package-manager      | package manager                           | `<pm>`     |
-| -       | -o         | --orm                  | orm                                       | `<orm>`    |
-| -       | -db        | --db                   | database ("pg" | "mysql" | "sqlite")      | `<db>`     |
-| -       | -a         | --auth                 | auth                                      | `<auth>`   |
-| -       | -ie        | --include-example      | include example                           | -          |
+| Command | Short Flag | Long Option            | Description                               | Argument      |
+|---------|------------|------------------------|-------------------------------------------|---------------|
+| init    | -          | -                      | initialise and configure kirimase         | -             |
+| -       | -sf        | --src-folder           | use a src folder                          | `yes` or `no` |
+| -       | -pm        | --package-manager      | package manager                           | `<pm>`        |
+| -       | -o         | --orm                  | orm                                       | `<orm>`       |
+| -       | -db        | --db                   | database ("pg" | "mysql" | "sqlite")      | `<db>`        |
+| -       | -a         | --auth                 | auth                                      | `<auth>`      |
+| -       | -ap        | --auth-providers       | auth-providers                            | `<providers>` |
+| -       | -ie        | --include-example      | include example                           | `yes` or `no` |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -120,19 +120,20 @@ Kirimase generates:
 You can run Kirimase entirely via the command line as follows:
 
 ```sh
-kirimase init -sf yes -pm pnpm --orm prisma -db pg -a next-auth -ap github discord -ie yes
+kirimase init -sf no -pm pnpm --orm prisma -db pg -a next-auth -ap github discord -p trpc shadcn-ui resend -ie yes
 ```
 
-| Command | Short Flag | Long Option            | Description                               | Argument      |
-|---------|------------|------------------------|-------------------------------------------|---------------|
-| init    | -          | -                      | initialise and configure kirimase         | -             |
-| -       | -sf        | --src-folder           | use a src folder                          | `yes` or `no` |
-| -       | -pm        | --package-manager      | package manager                           | `<pm>`        |
-| -       | -o         | --orm                  | orm                                       | `<orm>`       |
-| -       | -db        | --db                   | database ("pg" | "mysql" | "sqlite")      | `<db>`        |
-| -       | -a         | --auth                 | auth                                      | `<auth>`      |
-| -       | -ap        | --auth-providers       | auth-providers                            | `<providers>` |
-| -       | -ie        | --include-example      | include example                           | `yes` or `no` |
+| Command | Short Flag | Long Option       | Description                        | Argument      |
+| ------- | ---------- | ----------------- | ---------------------------------- | ------------- |
+| init    | -          | -                 | initialise and configure kirimase  | -             |
+| -       | -sf        | --src-folder      | use a src folder                   | `yes` or `no` |
+| -       | -pm        | --package-manager | package manager                    | `<pm>`        |
+| -       | -o         | --orm             | orm                                | `<orm>`       |
+| -       | -db        | --db              | database ("pg", "mysql", "sqlite") | `<db>`        |
+| -       | -a         | --auth            | auth                               | `<auth>`      |
+| -       | -ap        | --auth-providers  | auth providers                     | `<providers>` |
+| -       | -p         | --packages        | packages                           | `<packages>`  |
+| -       | -ie        | --include-example | include example                    | `yes` or `no` |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,24 @@ Kirimase generates:
 
 - Scaffolds views using Shadcn-UI to enable immediate CRUD operations (including select fields for adding relations and datepickers for dates).
 
+## Run in non-interactive mode
+
+You can run Kirimase entirely via the command line as follows:
+
+```sh
+kirimase init -sf -pm pnpm -o prisma -db postgres -a next-auth -ie      
+```
+
+| Command | Short Flag | Long Option            | Description                               | Argument   |
+|---------|------------|------------------------|-------------------------------------------|------------|
+| init    | -          | -                      | initialise and configure kirimase within directory | -          |
+| -       | -sf        | --src-folder           | use a src folder                          | -          |
+| -       | -pm        | --package-manager      | preferred package manager                 | `<pm>`     |
+| -       | -o         | --orm                  | preferred orm                             | `<orm>`    |
+| -       | -db        | --db                   | preferred database                        | `<db>`     |
+| -       | -a         | --auth                 | preferred auth                            | `<auth>`   |
+| -       | -ie        | --include-example      | include example                           | -          |
+
 ## Contributing
 
 Keen on enhancing Kirimase? Contributions, bug reports, and feature requests are always welcome. Feel free to open an issue or submit a pull request.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ You can run Kirimase entirely via the command line as follows:
 
 ```sh
 kirimase init -sf no -pm pnpm --orm prisma -db pg -a next-auth -ap github discord -p trpc shadcn-ui resend -ie yes
+kirimase generate -r model api_route -t blog -b yes -f "title:String::yes:yes" -f "content:String::yes:yes" -i title -m yes
 ```
 
 | Command | Short Flag | Long Option       | Description                              | Argument      |

--- a/README.md
+++ b/README.md
@@ -120,17 +120,17 @@ Kirimase generates:
 You can run Kirimase entirely via the command line as follows:
 
 ```sh
-kirimase init -sf -pm pnpm -o prisma -db postgres -a next-auth -ie      
+kirimase init -sf -pm pnpm --orm prisma -db pg -a next-auth -ap github discord -ie
 ```
 
 | Command | Short Flag | Long Option            | Description                               | Argument   |
 |---------|------------|------------------------|-------------------------------------------|------------|
-| init    | -          | -                      | initialise and configure kirimase within directory | -          |
+| init    | -          | -                      | initialise and configure kirimase         | -          |
 | -       | -sf        | --src-folder           | use a src folder                          | -          |
-| -       | -pm        | --package-manager      | preferred package manager                 | `<pm>`     |
-| -       | -o         | --orm                  | preferred orm                             | `<orm>`    |
-| -       | -db        | --db                   | preferred database                        | `<db>`     |
-| -       | -a         | --auth                 | preferred auth                            | `<auth>`   |
+| -       | -pm        | --package-manager      | package manager                           | `<pm>`     |
+| -       | -o         | --orm                  | orm                                       | `<orm>`    |
+| -       | -db        | --db                   | database ("pg" | "mysql" | "sqlite")      | `<db>`     |
+| -       | -a         | --auth                 | auth                                      | `<auth>`   |
 | -       | -ie        | --include-example      | include example                           | -          |
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Kirimase generates:
 You can run Kirimase entirely via the command line as follows:
 
 ```sh
-kirimase init -sf -pm pnpm --orm prisma -db pg -a next-auth -ap github discord -ie
+kirimase init -sf yes -pm pnpm --orm prisma -db pg -a next-auth -ap github discord -ie yes
 ```
 
 | Command | Short Flag | Long Option            | Description                               | Argument   |

--- a/README.md
+++ b/README.md
@@ -123,17 +123,17 @@ You can run Kirimase entirely via the command line as follows:
 kirimase init -sf no -pm pnpm --orm prisma -db pg -a next-auth -ap github discord -p trpc shadcn-ui resend -ie yes
 ```
 
-| Command | Short Flag | Long Option       | Description                        | Argument      |
-| ------- | ---------- | ----------------- | ---------------------------------- | ------------- |
-| init    | -          | -                 | initialise and configure kirimase  | -             |
-| -       | -sf        | --src-folder      | use a src folder                   | `yes` or `no` |
-| -       | -pm        | --package-manager | package manager                    | `<pm>`        |
-| -       | -o         | --orm             | orm                                | `<orm>`       |
-| -       | -db        | --db              | database ("pg", "mysql", "sqlite") | `<db>`        |
-| -       | -a         | --auth            | auth                               | `<auth>`      |
-| -       | -ap        | --auth-providers  | auth providers                     | `<providers>` |
-| -       | -p         | --packages        | packages                           | `<packages>`  |
-| -       | -ie        | --include-example | include example                    | `yes` or `no` |
+| Command | Short Flag | Long Option       | Description                              | Argument      |
+| ------- | ---------- | ----------------- | ---------------------------------------- | ------------- |
+| init    | -          | -                 | initialise and configure kirimase        | -             |
+| -       | -sf        | --src-folder      | use a src folder                         | `yes` or `no` |
+| -       | -pm        | --package-manager | package manager                          | `<pm>`        |
+| -       | -o         | --orm             | orm                                      | `<orm>`       |
+| -       | -db        | --db              | database ("pg", "mysql", "sqlite")       | `<db>`        |
+| -       | -a         | --auth            | auth                                     | `<auth>`      |
+| -       | -ap        | --auth-providers  | auth providers                           | `<providers>` |
+| -       | -p         | --packages        | packages ("trpc", "shadcn-ui", "resend") | `<packages>`  |
+| -       | -ie        | --include-example | include example                          | `yes` or `no` |
 
 ## Contributing
 

--- a/src/commands/add/auth/next-auth/index.ts
+++ b/src/commands/add/auth/next-auth/index.ts
@@ -24,9 +24,10 @@ import { updateSignInComponentWithShadcnUI } from "../../misc/shadcn-ui/index.js
 import { addToDotEnv } from "../../orm/drizzle/generators.js";
 import { addToPrismaSchema } from "../../../generate/utils.js";
 import { prismaGenerate } from "../../orm/utils.js";
+import { InitOptions } from "../../../../types.js";
 
-export const addNextAuth = async () => {
-  const providers = (await checkbox({
+export const addNextAuth = async (options: InitOptions) => {
+  const providers = options.authProviders || (await checkbox({
     message: "Select a provider to add",
     choices: Object.keys(AuthProviders).map((p) => {
       return { name: p, value: p };

--- a/src/commands/add/auth/next-auth/index.ts
+++ b/src/commands/add/auth/next-auth/index.ts
@@ -26,8 +26,8 @@ import { addToPrismaSchema } from "../../../generate/utils.js";
 import { prismaGenerate } from "../../orm/utils.js";
 import { InitOptions } from "../../../../types.js";
 
-export const addNextAuth = async (options: InitOptions) => {
-  const providers = options.authProviders || (await checkbox({
+export const addNextAuth = async (options?: InitOptions) => {
+  const providers = options?.authProviders || (await checkbox({
     message: "Select a provider to add",
     choices: Object.keys(AuthProviders).map((p) => {
       return { name: p, value: p };

--- a/src/commands/add/index.ts
+++ b/src/commands/add/index.ts
@@ -8,12 +8,12 @@ import { installShadcnUI } from "./misc/shadcn-ui/index.js";
 import { consola } from "consola";
 import { initProject } from "../init/index.js";
 import { addPrisma } from "./orm/prisma/index.js";
-import { AuthType, ORMType, PackageChoice } from "../../types.js";
+import { AuthType, InitOptions, ORMType, PackageChoice } from "../../types.js";
 import { addClerk } from "./auth/clerk/index.js";
 import { addResend } from "./misc/resend/index.js";
 import { addLucia } from "./auth/lucia/index.js";
 
-export const addPackage = async () => {
+export const addPackage = async (initOptions?: InitOptions) => {
   const config = readConfigFile();
 
   if (config) {
@@ -22,19 +22,19 @@ export const addPackage = async () => {
     const nullOption = { name: "None", value: null };
     // check if orm
     if (orm === undefined) {
-      const ormToInstall = (await select({
+      const ormToInstall = initOptions.orm || (await select({
         message: "Select an ORM to use:",
         choices: [...Packages.orm, new Separator(), nullOption],
       })) as ORMType | null;
 
-      if (ormToInstall === "drizzle") await addDrizzle();
-      if (ormToInstall === "prisma") await addPrisma();
+      if (ormToInstall === "drizzle") await addDrizzle(initOptions);
+      if (ormToInstall === "prisma") await addPrisma(initOptions);
       if (ormToInstall === null)
         updateConfigFile({ orm: null, driver: null, provider: null });
     }
     // check if auth
     if (auth === undefined) {
-      const authToInstall = (await select({
+      const authToInstall = initOptions.auth || (await select({
         message: "Select an authentication package to use:",
         choices: [...Packages.auth, new Separator(), nullOption],
       })) as AuthType | null;
@@ -73,6 +73,6 @@ export const addPackage = async () => {
     }
   } else {
     consola.warn("No config file found, initializing project...");
-    initProject();
+    initProject(initOptions);
   }
 };

--- a/src/commands/add/index.ts
+++ b/src/commands/add/index.ts
@@ -22,7 +22,7 @@ export const addPackage = async (initOptions?: InitOptions) => {
     const nullOption = { name: "None", value: null };
     // check if orm
     if (orm === undefined) {
-      const ormToInstall = initOptions.orm || (await select({
+      const ormToInstall = initOptions?.orm || (await select({
         message: "Select an ORM to use:",
         choices: [...Packages.orm, new Separator(), nullOption],
       })) as ORMType | null;
@@ -34,7 +34,7 @@ export const addPackage = async (initOptions?: InitOptions) => {
     }
     // check if auth
     if (auth === undefined) {
-      const authToInstall = initOptions.auth || (await select({
+      const authToInstall = initOptions?.auth || (await select({
         message: "Select an authentication package to use:",
         choices: [...Packages.auth, new Separator(), nullOption],
       })) as AuthType | null;
@@ -58,7 +58,7 @@ export const addPackage = async (initOptions?: InitOptions) => {
       );
     }
     if (uninstalledPackages.length > 0) {
-      const packageToInstall = await checkbox({
+      const packageToInstall = initOptions?.packages || await checkbox({
         message: "Select any miscellaneous packages to add:",
         choices: uninstalledPackages,
       });

--- a/src/commands/add/index.ts
+++ b/src/commands/add/index.ts
@@ -39,7 +39,7 @@ export const addPackage = async (initOptions?: InitOptions) => {
         choices: [...Packages.auth, new Separator(), nullOption],
       })) as AuthType | null;
 
-      if (authToInstall === "next-auth") await addNextAuth();
+      if (authToInstall === "next-auth") await addNextAuth(initOptions);
       if (authToInstall === "clerk") await addClerk();
       if (authToInstall === "lucia") await addLucia();
       if (authToInstall === null) updateConfigFile({ auth: null });

--- a/src/commands/add/index.ts
+++ b/src/commands/add/index.ts
@@ -13,7 +13,7 @@ import { addClerk } from "./auth/clerk/index.js";
 import { addResend } from "./misc/resend/index.js";
 import { addLucia } from "./auth/lucia/index.js";
 
-export const addPackage = async (initOptions?: InitOptions) => {
+export const addPackage = async (options?: InitOptions) => {
   const config = readConfigFile();
 
   if (config) {
@@ -22,24 +22,24 @@ export const addPackage = async (initOptions?: InitOptions) => {
     const nullOption = { name: "None", value: null };
     // check if orm
     if (orm === undefined) {
-      const ormToInstall = initOptions?.orm || (await select({
+      const ormToInstall = options?.orm || (await select({
         message: "Select an ORM to use:",
         choices: [...Packages.orm, new Separator(), nullOption],
       })) as ORMType | null;
 
-      if (ormToInstall === "drizzle") await addDrizzle(initOptions);
-      if (ormToInstall === "prisma") await addPrisma(initOptions);
+      if (ormToInstall === "drizzle") await addDrizzle(options);
+      if (ormToInstall === "prisma") await addPrisma(options);
       if (ormToInstall === null)
         updateConfigFile({ orm: null, driver: null, provider: null });
     }
     // check if auth
     if (auth === undefined) {
-      const authToInstall = initOptions?.auth || (await select({
+      const authToInstall = options?.auth || (await select({
         message: "Select an authentication package to use:",
         choices: [...Packages.auth, new Separator(), nullOption],
       })) as AuthType | null;
 
-      if (authToInstall === "next-auth") await addNextAuth(initOptions);
+      if (authToInstall === "next-auth") await addNextAuth(options);
       if (authToInstall === "clerk") await addClerk();
       if (authToInstall === "lucia") await addLucia();
       if (authToInstall === null) updateConfigFile({ auth: null });
@@ -58,7 +58,7 @@ export const addPackage = async (initOptions?: InitOptions) => {
       );
     }
     if (uninstalledPackages.length > 0) {
-      const packageToInstall = initOptions?.packages || await checkbox({
+      const packageToInstall = options?.packages || await checkbox({
         message: "Select any miscellaneous packages to add:",
         choices: uninstalledPackages,
       });
@@ -73,6 +73,6 @@ export const addPackage = async (initOptions?: InitOptions) => {
     }
   } else {
     consola.warn("No config file found, initializing project...");
-    initProject(initOptions);
+    initProject(options);
   }
 };

--- a/src/commands/add/orm/drizzle/index.ts
+++ b/src/commands/add/orm/drizzle/index.ts
@@ -74,8 +74,8 @@ export const addDrizzle = async (initOptions?: InitOptions) => {
   if (dbProvider === "neon")
     databaseUrl = databaseUrl.concat("?sslmode=require");
 
-  const includeExampleModel = typeof initOptions.includeExample === 'boolean' ?
-    initOptions.includeExample :
+  const includeExampleModel = typeof initOptions?.includeExample === 'string' ?
+    initOptions.includeExample === 'yes' :
     await confirm({
       message:
         "Would you like to include an example model? (suggested for new users)",

--- a/src/commands/add/orm/drizzle/index.ts
+++ b/src/commands/add/orm/drizzle/index.ts
@@ -1,5 +1,5 @@
 import { confirm, select } from "@inquirer/prompts";
-import { DBProvider, DBType } from "../../../../types.js";
+import { DBProvider, DBType, InitOptions } from "../../../../types.js";
 import {
   addPackageToConfig,
   createFolder,
@@ -21,13 +21,13 @@ import {
 } from "./generators.js";
 import { DBProviders } from "../../../init/utils.js";
 
-export const addDrizzle = async () => {
+export const addDrizzle = async (initOptions?: InitOptions) => {
   const { preferredPackageManager, hasSrc, rootPath } = readConfigFile();
 
   let libPath = "";
   hasSrc ? (libPath = "src/lib") : (libPath = "lib");
 
-  const dbType = (await select({
+  const dbType = initOptions.db || (await select({
     message: "Please choose your DB type",
     choices: [
       { name: "Postgres", value: "pg" },
@@ -74,11 +74,13 @@ export const addDrizzle = async () => {
   if (dbProvider === "neon")
     databaseUrl = databaseUrl.concat("?sslmode=require");
 
-  const includeExampleModel = await confirm({
-    message:
-      "Would you like to include an example model? (suggested for new users)",
-    default: true,
-  });
+  const includeExampleModel = typeof initOptions.includeExample === 'boolean' ?
+    initOptions.includeExample :
+    await confirm({
+      message:
+        "Would you like to include an example model? (suggested for new users)",
+      default: true,
+    });
 
   // create all the files here
 

--- a/src/commands/add/orm/prisma/index.ts
+++ b/src/commands/add/orm/prisma/index.ts
@@ -24,11 +24,11 @@ import {
 import { consola } from "consola";
 import { addToPrismaSchema } from "../../../generate/utils.js";
 
-export const addPrisma = async (initOptions: InitOptions) => {
+export const addPrisma = async (initOptions?: InitOptions) => {
   const { preferredPackageManager, hasSrc } = readConfigFile();
   const rootPath = hasSrc ? "src/" : "";
   // ask for db type
-  const dbType = initOptions.db || (await select({
+  const dbType = initOptions?.db || (await select({
     message: "Please choose your DB type",
     choices: [
       { name: "Postgres", value: "pg" },
@@ -82,7 +82,7 @@ export const addPrisma = async (initOptions: InitOptions) => {
   // update tsconfig with import alias for prisma types
   updateTsConfigPrismaTypeAlias();
 
-  const includeExampleModel = typeof initOptions.includeExample === 'string' ?
+  const includeExampleModel = typeof initOptions?.includeExample === 'string' ?
     initOptions.includeExample === 'yes' :
     await confirm({
       message:

--- a/src/commands/add/orm/prisma/index.ts
+++ b/src/commands/add/orm/prisma/index.ts
@@ -1,5 +1,5 @@
 import { confirm, select } from "@inquirer/prompts";
-import { DBType } from "../../../../types.js";
+import { DBType, InitOptions } from "../../../../types.js";
 import {
   addPackageToConfig,
   createFile,
@@ -24,11 +24,11 @@ import {
 import { consola } from "consola";
 import { addToPrismaSchema } from "../../../generate/utils.js";
 
-export const addPrisma = async () => {
+export const addPrisma = async (initOptions: InitOptions) => {
   const { preferredPackageManager, hasSrc } = readConfigFile();
   const rootPath = hasSrc ? "src/" : "";
   // ask for db type
-  const dbType = (await select({
+  const dbType = initOptions.db || (await select({
     message: "Please choose your DB type",
     choices: [
       { name: "Postgres", value: "pg" },
@@ -82,11 +82,13 @@ export const addPrisma = async () => {
   // update tsconfig with import alias for prisma types
   updateTsConfigPrismaTypeAlias();
 
-  const includeExampleModel = await confirm({
-    message:
-      "Would you like to include an example model? (suggested for new users)",
-    default: true,
-  });
+  const includeExampleModel = typeof initOptions.includeExample === 'boolean' ?
+    initOptions.includeExample :
+    await confirm({
+      message:
+        "Would you like to include an example model? (suggested for new users)",
+      default: true,
+    });
 
   // create all the files here
 

--- a/src/commands/add/orm/prisma/index.ts
+++ b/src/commands/add/orm/prisma/index.ts
@@ -82,8 +82,8 @@ export const addPrisma = async (initOptions: InitOptions) => {
   // update tsconfig with import alias for prisma types
   updateTsConfigPrismaTypeAlias();
 
-  const includeExampleModel = typeof initOptions.includeExample === 'boolean' ?
-    initOptions.includeExample :
+  const includeExampleModel = typeof initOptions.includeExample === 'string' ?
+    initOptions.includeExample === 'yes' :
     await confirm({
       message:
         "Would you like to include an example model? (suggested for new users)",

--- a/src/commands/generate/generators/model/index.ts
+++ b/src/commands/generate/generators/model/index.ts
@@ -1,5 +1,5 @@
 import { consola } from "consola";
-import { DBType } from "../../../../types.js";
+import { BuildOptions, DBType } from "../../../../types.js";
 import { createFile, readConfigFile, runCommand } from "../../../../utils.js";
 import { prismaFormat, prismaGenerate } from "../../../add/orm/utils.js";
 import { Schema } from "../../types.js";
@@ -12,7 +12,8 @@ import { confirm } from "@inquirer/prompts";
 export async function scaffoldModel(
   schema: Schema,
   dbType: DBType,
-  hasSrc: boolean
+  hasSrc: boolean,
+  buildOptions?: BuildOptions
 ) {
   const { tableName } = schema;
   const { orm, preferredPackageManager, driver } = readConfigFile();
@@ -40,9 +41,11 @@ export async function scaffoldModel(
   createFile(mutationPath, generateMutationContent(schema, driver, orm));
 
   // migrate db
-  const migrate = await confirm({
-    message: "Would you like to generate the migration and migrate the DB?",
-  });
+  const migrate = typeof buildOptions?.migrate === 'string' ?
+    buildOptions?.migrate === 'yes' :
+    await confirm({
+      message: "Would you like to generate the migration and migrate the DB?",
+    });
   if (!migrate) return;
   if (orm === "drizzle") {
     await runCommand(preferredPackageManager, ["run", "db:generate"]);

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -10,20 +10,22 @@
 
 import { select } from "@inquirer/prompts";
 import { createConfigFile } from "../../utils.js";
-import { PMType } from "../../types.js";
+import { InitOptions, PMType } from "../../types.js";
 import { consola } from "consola";
 import { addPackage } from "../add/index.js";
 
-export async function initProject() {
-  const srcExists = await select({
-    message: "Are you using a 'src' folder?",
-    choices: [
-      { name: "Yes", value: true },
-      { name: "No", value: false },
-    ],
-  });
+export async function initProject(options?: InitOptions) {
+  const srcExists = typeof options.srcFolder === 'boolean' ?
+    options.srcFolder :
+    await select({
+      message: "Are you using a 'src' folder?",
+      choices: [
+        { name: "Yes", value: true },
+        { name: "No", value: false },
+      ],
+    });
 
-  const preferredPackageManager = (await select({
+  const preferredPackageManager = options.packageManager || (await select({
     message: "Please pick your preferred package manager",
     choices: [
       { name: "NPM", value: "npm" },
@@ -44,5 +46,5 @@ export async function initProject() {
   });
   consola.success("Kirimase initialized!");
   consola.info("You can now add packages.");
-  addPackage();
+  addPackage(options);
 }

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -15,8 +15,8 @@ import { consola } from "consola";
 import { addPackage } from "../add/index.js";
 
 export async function initProject(options?: InitOptions) {
-  const srcExists = typeof options.srcFolder === 'boolean' ?
-    options.srcFolder :
+  const srcExists = typeof options?.hasSrcFolder === 'string' ?
+    options.hasSrcFolder === 'true' :
     await select({
       message: "Are you using a 'src' folder?",
       choices: [
@@ -25,7 +25,7 @@ export async function initProject(options?: InitOptions) {
       ],
     });
 
-  const preferredPackageManager = options.packageManager || (await select({
+  const preferredPackageManager = options?.packageManager || (await select({
     message: "Please pick your preferred package manager",
     choices: [
       { name: "NPM", value: "npm" },

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -16,7 +16,7 @@ import { addPackage } from "../add/index.js";
 
 export async function initProject(options?: InitOptions) {
   const srcExists = typeof options?.hasSrcFolder === 'string' ?
-    options.hasSrcFolder === 'true' :
+    options.hasSrcFolder === 'yes' :
     await select({
       message: "Are you using a 'src' folder?",
       choices: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,12 @@ program.name("kirimase").description("Kirimase CLI").version("0.0.17");
 program
   .command("init")
   .description("initialise and configure kirimase within directory")
+  .option("-sf, --src-folder", "use a src folder")
+  .option("-pm, --package-manager <pm>", "preferred package manager")
+  .option("-o, --orm <orm>", "preferred orm")
+  .option("-db, --db <db>", "preferred database")
+  .option("-a, --auth <auth>", "preferred auth")
+  .option("-ie, --include-example", "include example")
   .action(initProject);
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { initProject } from "./commands/init/index.js";
 import { buildSchema } from "./commands/generate/index.js";
 import { addPackage } from "./commands/add/index.js";
 import { updateConfigFileAfterUpdate } from "./utils.js";
+import { ColumnType, DBField } from "./types.js";
 
 const program = new Command();
 program.name("kirimase").description("Kirimase CLI").version("0.0.17");
@@ -16,6 +17,28 @@ addCommonOptions(program.command("init"))
 program
   .command("generate")
   .description("Generate a new resource")
+  .option("-r, --resources <resources...>", "resources")
+  .option("-t, --table <table>", "table")
+  .option("-b, --belongs-to-user <belongs-to-user>", "belongs to user")
+  .option("-i, --index <index>", "index")
+  .option("-m, --migrate <migrate>", "migrate")
+  .option(
+    "-f, --field <field>",
+    "fields. Format: name:type:references:not-null:cascade. Example: blog:string::true:true",
+    (value, previous) => {
+      const [name, type, references, notNull, cascade] = value.split(":");
+      const field: DBField = {
+        name,
+        type: type as ColumnType,
+        references,
+        notNull: notNull === "true",
+        cascade: cascade === "true",
+      };
+      previous.push(field);
+      return previous;
+    },
+    []
+  )
   .action(buildSchema);
 
 addCommonOptions(program.command("add"))

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,13 +12,13 @@ program.name("kirimase").description("Kirimase CLI").version("0.0.17");
 program
   .command("init")
   .description("initialise and configure kirimase within directory")
-  .option("-sf, --has-src-folder <has-source-folder>", "use a src folder")
+  .option("-sf, --has-src-folder <has>", "has a src folder")
   .option("-pm, --package-manager <pm>", "preferred package manager")
   .option("-o, --orm <orm>", "preferred orm")
   .option("-db, --db <db>", "preferred database")
   .option("-a, --auth <auth>", "preferred auth")
   .option("-ap, --auth-providers <auth-providers>", "auth providers")
-  .option("-ie, --include-example", "include example")
+  .option("-ie, --include-example <include>", "include example")
   .action(initProject);
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ program
   .option("-o, --orm <orm>", "preferred orm")
   .option("-db, --db <db>", "preferred database")
   .option("-a, --auth <auth>", "preferred auth")
-  .option("-ap, --auth-providers <auth-providers>", "auth providers")
+  .option("-ap, --auth-providers <auth-providers...>", "auth providers")
   .option("-ie, --include-example <include>", "include example")
   .action(initProject);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,14 @@ program
 program
   .command("add")
   .description("Add and setup additional packages")
+  .option("-sf, --has-src-folder <has>", "has a src folder")
+  .option("-pm, --package-manager <pm>", "preferred package manager")
+  .option("-o, --orm <orm>", "preferred orm")
+  .option("-db, --db <db>", "preferred database")
+  .option("-a, --auth <auth>", "preferred auth")
+  .option("-ap, --auth-providers <auth-providers...>", "auth providers")
+  .option("-p, --packages <packages...>", "packages")
+  .option("-ie, --include-example <include>", "include example")
   .action(addPackage);
 
 program

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,12 @@ program.name("kirimase").description("Kirimase CLI").version("0.0.17");
 program
   .command("init")
   .description("initialise and configure kirimase within directory")
-  .option("-sf, --src-folder", "use a src folder")
+  .option("-sf, --has-src-folder <has-source-folder>", "use a src folder")
   .option("-pm, --package-manager <pm>", "preferred package manager")
   .option("-o, --orm <orm>", "preferred orm")
   .option("-db, --db <db>", "preferred database")
   .option("-a, --auth <auth>", "preferred auth")
+  .option("-ap, --auth-providers <auth-providers>", "auth providers")
   .option("-ie, --include-example", "include example")
   .action(initProject);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,17 +9,8 @@ import { updateConfigFileAfterUpdate } from "./utils.js";
 const program = new Command();
 program.name("kirimase").description("Kirimase CLI").version("0.0.17");
 
-program
-  .command("init")
+addCommonOptions(program.command("init"))
   .description("initialise and configure kirimase within directory")
-  .option("-sf, --has-src-folder <has>", "has a src folder")
-  .option("-pm, --package-manager <pm>", "preferred package manager")
-  .option("-o, --orm <orm>", "preferred orm")
-  .option("-db, --db <db>", "preferred database")
-  .option("-a, --auth <auth>", "preferred auth")
-  .option("-ap, --auth-providers <auth-providers...>", "auth providers")
-  .option("-p, --packages <packages...>", "packages")
-  .option("-ie, --include-example <include>", "include example")
   .action(initProject);
 
 program
@@ -27,17 +18,8 @@ program
   .description("Generate a new resource")
   .action(buildSchema);
 
-program
-  .command("add")
+addCommonOptions(program.command("add"))
   .description("Add and setup additional packages")
-  .option("-sf, --has-src-folder <has>", "has a src folder")
-  .option("-pm, --package-manager <pm>", "preferred package manager")
-  .option("-o, --orm <orm>", "preferred orm")
-  .option("-db, --db <db>", "preferred database")
-  .option("-a, --auth <auth>", "preferred auth")
-  .option("-ap, --auth-providers <auth-providers...>", "auth providers")
-  .option("-p, --packages <packages...>", "packages")
-  .option("-ie, --include-example <include>", "include example")
   .action(addPackage);
 
 program
@@ -46,3 +28,15 @@ program
   .action(updateConfigFileAfterUpdate);
 
 program.parse(process.argv);
+
+function addCommonOptions(command: Command) {
+  return command
+    .option("-sf, --has-src-folder <has>", "has a src folder")
+    .option("-pm, --package-manager <pm>", "preferred package manager")
+    .option("-o, --orm <orm>", "preferred orm")
+    .option("-db, --db <db>", "preferred database")
+    .option("-a, --auth <auth>", "preferred auth")
+    .option("-ap, --auth-providers <auth-providers...>", "auth providers")
+    .option("-p, --packages <packages...>", "packages")
+    .option("-ie, --include-example <include>", "include example");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ program
   .option("-db, --db <db>", "preferred database")
   .option("-a, --auth <auth>", "preferred auth")
   .option("-ap, --auth-providers <auth-providers...>", "auth providers")
+  .option("-p, --packages <packages...>", "packages")
   .option("-ie, --include-example <include>", "include example")
   .action(initProject);
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -90,6 +90,17 @@ export type Config = {
 
 export type UpdateConfig = Partial<Config>;
 
+export type InitOptions = {
+  hasSrcFolder?: 'yes' | 'no';
+  packageManager?: PMType;
+  orm?: ORMType;
+  db?: DBType;
+  auth?: AuthType;
+  authProviders?: AuthProvider[];
+  packages?: AvailablePackage[];
+  includeExample?: 'yes' | 'no';
+}
+
 export type ScaffoldSchema = {
   tableName: string;
   fields: DBField[];
@@ -147,14 +158,3 @@ export type DotEnvItem = {
   customZodImplementation?: string;
   public?: boolean;
 };
-
-export type InitOptions = {
-  hasSrcFolder?: boolean;
-  packageManager?: PMType;
-  orm?: ORMType;
-  db?: DBType;
-  auth?: AuthType;
-  authProviders?: AuthProvider[];
-  packages?: AvailablePackage[];
-  includeExample?: boolean;
-}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -155,5 +155,6 @@ export type InitOptions = {
   db?: DBType;
   auth?: AuthType;
   authProviders?: AuthProvider[];
+  packages?: AvailablePackage[];
   includeExample?: boolean;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,5 @@
+import { AuthProvider } from "./commands/add/auth/next-auth/utils.ts";
+
 export type DBType = "pg" | "mysql" | "sqlite";
 export type DBProviderItem = {
   name: string;
@@ -147,10 +149,11 @@ export type DotEnvItem = {
 };
 
 export type InitOptions = {
-  srcFolder?: boolean;
+  hasSrcFolder?: boolean;
   packageManager?: PMType;
   orm?: ORMType;
   db?: DBType;
   auth?: AuthType;
+  authProviders?: AuthProvider[];
   includeExample?: boolean;
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -145,3 +145,12 @@ export type DotEnvItem = {
   customZodImplementation?: string;
   public?: boolean;
 };
+
+export type InitOptions = {
+  srcFolder?: boolean;
+  packageManager?: PMType;
+  orm?: ORMType;
+  db?: DBType;
+  auth?: AuthType;
+  includeExample?: boolean;
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -91,15 +91,24 @@ export type Config = {
 export type UpdateConfig = Partial<Config>;
 
 export type InitOptions = {
-  hasSrcFolder?: 'yes' | 'no';
+  hasSrcFolder?: "yes" | "no";
   packageManager?: PMType;
   orm?: ORMType;
   db?: DBType;
   auth?: AuthType;
   authProviders?: AuthProvider[];
   packages?: AvailablePackage[];
-  includeExample?: 'yes' | 'no';
-}
+  includeExample?: "yes" | "no";
+};
+
+export type BuildOptions = {
+  resources?: ("model" | "api_route" | "trpc_route" | "views_and_components")[];
+  table?: string
+  belongsToUser?: 'yes' | 'no'
+  index?: string
+  field?: DBField[]
+  migrate?: 'yes' | 'no'
+};
 
 export type ScaffoldSchema = {
   tableName: string;


### PR DESCRIPTION
Closes https://github.com/nicoalbanese/kirimase/issues/7

Allows for non-interactive mode.

Output:

```sh
➜  kirimase git:(master) ✗ pnpm run dev2 init -sf -pm pnpm -o prisma -db postgres -a next-auth -ie      

> kirimase@0.0.17 dev2 /xyz/kirimase
> node dist/index.js "init" "-sf" "-pm" "pnpm" "-o" "prisma" "-db" "postgres" "-a" "next-auth" "-ie"

✔ File created at ./kirimase.config.json                            2:12:19 AM
✔ Kirimase initialized!                                             2:12:19 AM
ℹ You can now add packages.                                         2:12:19 AM
✔ File created at prisma/schema.prisma                              2:12:19 AM
✔ File created at src/lib/db/index.ts                               2:12:19 AM
✔ File replaced at prisma/schema.prisma                             2:12:19 AM
✔ Added Computer to Prisma schema                                   2:12:19 AM
✔ File created at src/lib/db/schema/computers.ts                    2:12:19 AM
✔ File created at src/lib/api/computers/queries.ts                  2:12:19 AM
✔ File created at src/lib/api/computers/mutations.ts                2:12:19 AM
[2:12:19 AM] ◐ Installing packages: zod@3.21.4 @t3-oss/env-nextjs prisma zod-prisma...
```