### PR TITLE
Only add `User` to Prisma model if `belongsToUser`

### DIFF
--- a/src/commands/generate/generators/model/schema/index.ts
+++ b/src/commands/generate/generators/model/schema/index.ts
@@ -240,7 +240,7 @@ const generatePrismaSchema = (
   }${generateIndexFields(schema, relations, usingPlanetscale)}
 }`;
   addToPrismaSchema(prismaSchemaContent, tableNameSingularCapitalised);
-  if (authType !== "clerk")
+  if (schema.belongsToUser && authType !== "clerk")
     addToPrismaModel(
       "User",
       `${tableNameCamelCase} ${tableNameSingularCapitalised}[]`


### PR DESCRIPTION
I had an issue where models I generate would include the `User` relation in the Prisma schema, even if I answer no to the question.

Log from my `kirimase generate` command:
```bash
my-kiri on  main [!?] via  v18.14.0
❯ kirimase generate
ℹ Quickly generate your Model (Drizzle schema + queries / mutations), Controllers (API Routes and TRPC Routes), and Views                                                             9:31:33 AM
? Please select the resources you would like to generate: Model
? Please enter the table name (plural and in snake_case): organizations
? Please select the type of this field: string
? Please enter the field name (in snake_case): name
? Is this field required? yes
? Would you like to add another field? yes
? Please select the type of this field: datetime
? Please enter the field name (in snake_case): created_at
? Is this field required? yes
? Would you like to add another field? yes
? Please select the type of this field: boolean
? Please enter the field name (in snake_case): is_subscribed
? Is this field required? yes
? Would you like to add another field? no
? Would you like to set up an index? no
? Does this model belong to the user? no
✔ File replaced at prisma/schema.
```

Resulting Prisma schema:
```javascript
// This is your Prisma schema file,
// learn more about it in the docs: https://pris.ly/d/prisma-schema

generator client {
  provider = "prisma-client-js"
}

// remove to keep concise...

model Organization {
  id           String   @id @default(cuid())
  name         String
  createdAt    DateTime
  isSubscribed Boolean

  User   User?   @relation(fields: [userId], references: [id])
  userId String?
}
```
## Fixed by adding a check
I noticed the `belongsToUser` check was omitted from the line changed in this PR. But not sure of the relevancy of the entire block given user relations are added in `prismaSchemaContent` above?

After the fix, generating models with belong-to-user answers "No" and "Yes" respectively now yields the schema changes below:

```javascript
// Answered no to belong-to-user.
model Desk {
  id    String @id @default(cuid())
  model String
}

// Answered yes to belong-to-user.
model Monitor {
  id     String @id @default(cuid())
  model  String
  userId String
  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
}
```