### PR TITLE
Use `uuid` datatype for Drizzle/Postgres `user_id`

### DIFF
--- a/src/commands/add/auth/lucia/utils.ts
+++ b/src/commands/add/auth/lucia/utils.ts
@@ -106,7 +106,7 @@ export const DrizzleAdapterDriverMappings: {
 };
 
 export const DrizzleLuciaSchema: { [k in DBType]: string } = {
-  pg: `import { pgTable, bigint, varchar } from "drizzle-orm/pg-core";
+  pg: `import { pgTable, bigint, varchar, uuid } from "drizzle-orm/pg-core";
 
 export const users = pgTable("auth_user", {
 	id: varchar("id", {
@@ -122,9 +122,7 @@ export const sessions = pgTable("user_session", {
 	id: varchar("id", {
 		length: 128
 	}).primaryKey(),
-	userId: varchar("user_id", {
-		length: 15
-	})
+	userId: uuid("user_id")
 		.notNull()
 		.references(() => users.id),
 	activeExpires: bigint("active_expires", {
@@ -139,9 +137,7 @@ export const keys = pgTable("user_key", {
 	id: varchar("id", {
 		length: 255
 	}).primaryKey(),
-	userId: varchar("user_id", {
-		length: 15
-	})
+	userId: uuid("user_id")
 		.notNull()
 		.references(() => users.id),
 	hashedPassword: varchar("hashed_password", {

--- a/src/commands/add/auth/next-auth/generators.ts
+++ b/src/commands/add/auth/next-auth/generators.ts
@@ -115,11 +115,12 @@ export const createDrizzleAuthSchema = (dbType: DBType) => {
   text,
   primaryKey,
   integer,
+  uuid,
 } from "drizzle-orm/pg-core";
 import type { AdapterAccount } from "@auth/core/adapters";
 
 export const users = pgTable("user", {
-  id: text("id").notNull().primaryKey(),
+  id: uuid("id").notNull().primaryKey(),
   name: text("name"),
   email: text("email").notNull(),
   emailVerified: timestamp("emailVerified", { mode: "date" }),
@@ -129,7 +130,7 @@ export const users = pgTable("user", {
 export const accounts = pgTable(
   "account",
   {
-    userId: text("userId")
+    userId: uuid("userId")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
     type: text("type").$type<AdapterAccount["type"]>().notNull(),
@@ -150,7 +151,7 @@ export const accounts = pgTable(
 
 export const sessions = pgTable("session", {
   sessionToken: text("sessionToken").notNull().primaryKey(),
-  userId: text("userId")
+  userId: uuid("userId")
     .notNull()
     .references(() => users.id, { onDelete: "cascade" }),
   expires: timestamp("expires", { mode: "date" }).notNull(),

--- a/src/commands/add/misc/stripe/generators.ts
+++ b/src/commands/add/misc/stripe/generators.ts
@@ -880,6 +880,7 @@ export const generateSubscriptionsDrizzleSchema = (
   primaryKey,
   timestamp,
   varchar,
+  uuid,
 } from "drizzle-orm/pg-core";${
         auth !== "clerk" ? `\nimport { users } from "./auth";` : ""
       }
@@ -887,7 +888,7 @@ export const generateSubscriptionsDrizzleSchema = (
 export const subscriptions = pgTable(
   "subscriptions",
   {
-    userId: varchar("user_id", { length: 255 })
+    userId: uuid("user_id")
       .unique()${auth !== "clerk" ? `\n      .references(() => users.id)` : ""},
     stripeCustomerId: varchar("stripe_customer_id", { length: 255 }).unique(),
     stripeSubscriptionId: varchar("stripe_subscription_id", {

--- a/src/commands/add/orm/drizzle/generators.ts
+++ b/src/commands/add/orm/drizzle/generators.ts
@@ -81,7 +81,7 @@ import { drizzle } from 'drizzle-orm/neon-http';
 import { env } from "@/lib/env.mjs";
 
 neonConfig.fetchConnectionCache = true;
- 
+
 export const sql = neon(env.DATABASE_URL);
 export const db = drizzle(sql);
 `;
@@ -90,7 +90,7 @@ export const db = drizzle(sql);
       indexTS = `import { sql } from '@vercel/postgres';
 import { drizzle } from 'drizzle-orm/vercel-postgres';
 import { env } from "@/lib/env.mjs";
- 
+
 export const db = drizzle(sql)
 `;
       break;
@@ -98,7 +98,7 @@ export const db = drizzle(sql)
       indexTS = `import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 import { env } from "@/lib/env.mjs";
- 
+
 const connectionString = env.DATABASE_URL
 const client = postgres(connectionString)
 export const db = drizzle(client);
@@ -110,12 +110,12 @@ import { RDSDataClient } from '@aws-sdk/client-rds-data';
 import { fromIni } from '@aws-sdk/credential-providers';
 import "dotenv/config";
 
- 
+
 const rdsClient = new RDSDataClient({
   	credentials: fromIni({ profile: env['PROFILE'] }),
 		region: 'us-east-1',
 });
- 
+
 export const db = drizzle(rdsClient, {
   database: env['DATABASE']!,
   secretArn: env['SECRET_ARN']!,
@@ -127,12 +127,12 @@ export const db = drizzle(rdsClient, {
       indexTS = `import { drizzle } from "drizzle-orm/planetscale-serverless";
 import { connect } from "@planetscale/database";
 import { env } from "@/lib/env.mjs";
- 
+
 // create the connection
 export const connection = connect({
   url: env.DATABASE_URL
 });
- 
+
 export const db = drizzle(connection);
 `;
       break;
@@ -140,16 +140,16 @@ export const db = drizzle(connection);
       indexTS = `import { drizzle } from "drizzle-orm/mysql2";
 import mysql from "mysql2/promise";
 import { env } from "@/lib/env.mjs";
- 
+
 export const poolConnection = mysql.createPool(env.DATABASE_URL);
- 
+
 export const db = drizzle(poolConnection);
 `;
       break;
     case "better-sqlite3":
       indexTS = `import { drizzle, BetterSQLite3Database } from 'drizzle-orm/better-sqlite3';
 import Database from 'better-sqlite3';
- 
+
 export const sqlite = new Database('sqlite.db');
 export const db: BetterSQLite3Database = drizzle(sqlite);
 `;
@@ -216,7 +216,7 @@ import { neon, neonConfig } from '@neondatabase/serverless';
 `;
       connectionLogic = `
 neonConfig.fetchConnectionCache = true;
- 
+
 const sql = neon(env.DATABASE_URL);
 const db = drizzle(sql);
 `;
@@ -257,7 +257,7 @@ const rdsClient = new RDSDataClient({
   	credentials: fromIni({ profile: process.env['PROFILE'] }),
 		region: 'us-east-1',
 });
- 
+
 const db = drizzle(rdsClient, {
   database: process.env['DATABASE']!,
   secretArn: process.env['SECRET_ARN']!,
@@ -274,7 +274,7 @@ import { connect } from "@planetscale/database";
 `;
       connectionLogic = `
 const connection = connect({ url: env.DATABASE_URL });
- 
+
 const db = drizzle(connection);
 `;
       break;
@@ -345,7 +345,7 @@ export const createInitSchema = (libPath?: string, dbType?: DBType) => {
   let initModel = "";
   switch (dbDriver) {
     case "pg":
-      initModel = `import { pgTable, serial, text, integer } from "drizzle-orm/pg-core";${
+      initModel = `import { pgTable, serial, text, integer, uuid } from "drizzle-orm/pg-core";${
         packages.includes("next-auth")
           ? '\nimport { users } from "./auth";'
           : ""
@@ -356,7 +356,7 @@ export const computers = pgTable("computers", {
   brand: text("brand").notNull(),
   cores: integer("cores").notNull(),${
     packages.includes("next-auth")
-      ? '\nuserId: integer("user_id").notNull().references(() => users.id)'
+      ? '\nuserId: uuid("user_id").notNull().references(() => users.id)'
       : ""
   }
 });`;


### PR DESCRIPTION
:tada: **First of all, thanks for trying to bring Ruby on Rails DX to the JavaScript ecosystem!**

### Why

Currently, for some reason `Auth.js` prescribes `text` for the user id, while they are using them as `uuid`. This is a bit of a problem from a [DB standpoint](https://stackoverflow.com/a/33838373/413403).

### What

This change is scoped only on the `Postgres` / `Drizzle` parts, since that's what I am familiar with. The best would be to change every DB datatype to UUIDs or big integers (`Auth.js` doesn't like that, unfortunately) for the user id.

Drizzle will transparently convert the values to string, so no change is required on the other sides.

### Other DB recommenedations out of scope
> These are out-of-scope for this PR, but I think we should think about it in the long term...

#### Timestamps for all models
It is best to have `created_at` / `updated_at` for all models, since they are pretty hard to add after the fact. Users can later remove them. `created_at` can be always auto-generated at insert (at least for Postgres).

#### Consolidate naming scheme
`Auth.js` people has weird naming schemes:

- All `Auth.js` tables use the singular form, like `user`, `account`, etc. in the database. The code still references them in the plural form. A good framework has to be consistent. This behaviour is overrideable, but not easy. 
- They also mix `snake_case` and `camelBack` in the DB depending on whether the column is an `oauth` data or `Auth.js`'s own. Users don't care, they need cleanliness. This is also not trivial to fix.

#### Use bigger ids
`bigserial` would be better to use in the long-run for database primary keys, engines can cope with them and aren't that big of deal for storage. A must have for large tables.

#### Linked accounts
It would be great to explicitly include information about the linked account. `user.name` can actually mean multiple things depending which provider did the user use first. Usually, it's the full name, but it can also mean the login name. It would be far better to save the `github_login_name`, etc. explicitly, so it can be used later for integrations.

Alternatively, this could be saved into a different table, too.

#### Template-based generation
As I created the PR, I have noticed that the file generation is basically done as string concatenation. Although, this is trivial, it is error prone. It would be far easier to create templates, in a templating language, where the substitutions can occur.

#### Idempotent generation
Based on the previous point, right now running the generation will append a new configuration to the generated files. `Rails` actually will ask the user what to do in a situation like this.

#### Reduce options
Just looking through the code, it was hard to follow which thing generated what. There are already too many options. It would be far better to start with a smaller subset of technologies first. Make those few well-tested and feature complete (like `tRPC` + `Drizzle` + `Postgres`). And only then include more things. The ecosystem needs a lot of consolidation already.

Sorry, for making this too long, just some toughts. :smile:  I hope, this project will succeed! :1st_place_medal: 