### PR TITLE
Enhanced Singular & Plural Conversions Using `pluralize` Library

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "commander": "^11.0.0",
     "consola": "^3.2.3",
     "execa": "^8.0.1",
+    "pluralize": "^8.0.0",
     "strip-json-comments": "^5.0.1"
   },
   "devDependencies": {

--- a/src/commands/generate/generators/model/queries/generators.ts
+++ b/src/commands/generate/generators/model/queries/generators.ts
@@ -1,4 +1,5 @@
 import { DBField } from "../../../../../types.js";
+import pluralize from "pluralize";
 import {
   formatFilePath,
   getDbIndexPath,
@@ -80,11 +81,11 @@ const generateDrizzleGetQuery = (schema: Schema, relations: DBField[]) => {
   const {
     tableNameCamelCase,
     tableNameFirstChar,
-    tableNameSingularCapitalised,
+    tableNamePluralCapitalised,
     tableNameSingular,
   } = formatTableName(tableName);
   const getAuth = generateAuthCheck(schema.belongsToUser);
-  return `export const get${tableNameSingularCapitalised}s = async () => {${getAuth}
+  return `export const get${tableNamePluralCapitalised} = async () => {${getAuth}
   const ${tableNameFirstChar} = await db.select(${
     relations.length > 0
       ? `{ ${tableNameSingular}: ${tableNameCamelCase}, ${relations
@@ -154,17 +155,17 @@ const generatePrismaGetQuery = (schema: Schema, relations: DBField[]) => {
   const {
     tableNameCamelCase,
     tableNameSingular,
-    tableNameSingularCapitalised,
+    tableNamePluralCapitalised,
     tableNameFirstChar,
   } = formatTableName(tableName);
   const getAuth = generateAuthCheck(schema.belongsToUser);
-  return `export const get${tableNameSingularCapitalised}s = async () => {${getAuth}
+  return `export const get${tableNamePluralCapitalised} = async () => {${getAuth}
   const ${tableNameFirstChar} = await db.${tableNameSingular}.findMany({${
     belongsToUser ? ` where: {userId: session?.user.id!}` : ""
   }${belongsToUser && relations.length > 0 ? ", " : ""}${
     relations.length > 0
       ? `include: { ${relations
-          .map((relation) => `${relation.references.slice(0, -1)}: true`)
+          .map((relation) => `${pluralize.singular(relation.references)}: true`)
           .join(", ")}}`
       : ""
   }});

--- a/src/commands/generate/generators/views.ts
+++ b/src/commands/generate/generators/views.ts
@@ -1,4 +1,5 @@
 import { DBField } from "../../../types.js";
+import pluralize from "pluralize";
 import {
   createFile,
   getFileContents,
@@ -228,7 +229,7 @@ const createformInputComponent = (field: DBField): string => {
               <Checkbox {...field} checked={!!field.value} onCheckedChange={field.onChange} value={""} />
             </FormControl>`;
   if (field.type.toLowerCase() == "references") {
-    const referencesSingular = field.references.slice(0, -1);
+    const referencesSingular = pluralize.singular(field.references);
     const entity = queryHasJoins(toCamelCase(field.references))
       ? `${referencesSingular}.${referencesSingular}`
       : referencesSingular;

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -1,5 +1,6 @@
 import { checkbox, confirm, input, select } from "@inquirer/prompts";
 import { consola } from "consola";
+import pluralize from "pluralize";
 import {
   DBField,
   DBType,
@@ -119,7 +120,7 @@ async function askForFields(orm: ORMType, dbType: DBType, tableName: string) {
           }),
       });
 
-      const fieldName = `${referencesTable.slice(0, -1)}_id`;
+      const fieldName = `${pluralize.singular(referencesTable)}_id`;
       const cascade = await confirm({
         message: "Would you like to cascade on delete?",
         default: false,

--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import pluralize from "pluralize";
 import {
   DBField,
   DBType,
@@ -30,7 +31,8 @@ export function capitalise(input: string): string {
 }
 
 export function capitaliseForZodSchema(input: string): string {
-  return input.charAt(0).toUpperCase() + input.slice(1, -1);
+  const singularInput = pluralize.singular(input);
+  return singularInput.charAt(0).toUpperCase() + singularInput.slice(1);
 }
 
 export const formatTableName = (tableName: string) => {
@@ -39,7 +41,10 @@ export const formatTableName = (tableName: string) => {
     tableNameCamelCase.charAt(0).toUpperCase() + tableNameCamelCase.slice(1);
   const tableNameSingularCapitalised =
     capitaliseForZodSchema(tableNameCamelCase);
-  const tableNameSingular = tableNameCamelCase.slice(0, -1);
+  const tableNameSingular = pluralize.singular(tableNameCamelCase);
+  const tableNamePlural = pluralize.plural(tableNameCamelCase);
+  const tableNamePluralCapitalised =
+    tableNamePlural.charAt(0).toUpperCase() + tableNamePlural.slice(1);
   const tableNameFirstChar = tableNameCamelCase.charAt(0);
   const tableNameNormalEnglishCapitalised = toNormalEnglish(
     tableName,
@@ -68,6 +73,7 @@ export const formatTableName = (tableName: string) => {
     tableNameCamelCase,
     tableNameSingular,
     tableNameSingularCapitalised,
+    tableNamePluralCapitalised,
     tableNameFirstChar,
     tableNameCapitalised,
     tableNameNormalEnglishCapitalised,
@@ -250,7 +256,7 @@ export function toNormalEnglish(
     .map((word) => capitalise(word))
     .join(" ");
 
-  const newOutput = singular ? output.slice(0, -1) : output;
+  const newOutput = singular ? pluralize.singular(output) : output;
 
   return lowercase ? newOutput.toLowerCase() : newOutput;
 }
@@ -299,7 +305,9 @@ export function getCurrentSchemas() {
         .filter((line) => line.includes("model") && line.includes("{"))
         .map((line) => line.split(" ")[1])
         .filter((item) => !excludedSchemas.includes(item))
-        .map((item) => `${item[0].toLowerCase()}${item.slice(1)}s`);
+        .map((item) =>
+          pluralize.plural(`${item[0].toLowerCase()}${item.slice(1)}`)
+        );
       return schemaNames;
     } else {
       consola.info(`Prisma schema file does not exist`);
@@ -339,8 +347,8 @@ export const addToPrismaSchema = (schema: string, modelName: string) => {
 export const formatPrismaModelName = (name: string) => {
   const lowerCase = name.toLowerCase();
   const firstLetter = lowerCase[0];
-  const plural = name + "s";
-  const pluralLowerCase = lowerCase + "s";
+  const plural = pluralize.plural(name);
+  const pluralLowerCase = pluralize.plural(lowerCase);
 
   return {
     lowerCase,


### PR DESCRIPTION
Thanks for great work on this awesome project @nicoalbanese! This PR addresses an issue with the current singular and plural conversions in the codebase. For instance, creating a `categories` entity currently results in files like `CategorieList.tsx` being generated, and leading to inconsistent and often incorrect naming conventions of files, fields and variables.

I propose integrating the `pluralize` library to resolve this. I've done some basic testing with drizzle and prisma and I haven't run into any issues with this yet. However, further testing is likely needed.

An alternative approach could involve requesting both singular and plural forms via CLI. However, this increases the steps required for input, making the process more cumbersome.

Feedback and suggestions, especially regarding testing and implementation, are highly appreciated.