### PR TITLE
fix: use new primary key syntax in drizzle

### DIFF
--- a/src/commands/add/auth/next-auth/generators.ts
+++ b/src/commands/add/auth/next-auth/generators.ts
@@ -272,7 +272,9 @@ export const accounts = pgTable(
     session_state: text("session_state"),
   },
   (account) => ({
-    compoundKey: primaryKey(account.provider, account.providerAccountId),
+    compoundKey: primaryKey({
+      columns: [account.provider, account.providerAccountId],
+    }),
   })
 );
 
@@ -292,7 +294,7 @@ export const verificationTokens = pgTable(
     expires: timestamp("expires", { mode: "date" }).notNull(),
   },
   (vt) => ({
-    compoundKey: primaryKey(vt.identifier, vt.token),
+    compoundKey: primaryKey({ columns: [vt.identifier, vt.token] }),
   })
 );
 `;
@@ -344,8 +346,9 @@ export const accounts = mysqlTable(
     session_state: varchar("session_state", { length: 255 }),
   },
   (account) => ({
-    compoundKey: primaryKey(account.provider, account.providerAccountId),
-  })
+    compoundKey: primaryKey({
+      columns: [account.provider, account.providerAccountId],
+    }),
 );
 
 export const sessions = mysqlTable("session", {
@@ -367,7 +370,7 @@ export const verificationTokens = mysqlTable(
     expires: timestamp("expires", { mode: "date" }).notNull(),
   },
   (vt) => ({
-    compoundKey: primaryKey(vt.identifier, vt.token),
+    compoundKey: primaryKey({ columns: [vt.identifier, vt.token] }),
   })
 );`;
     case "sqlite":
@@ -405,7 +408,9 @@ export const accounts = sqliteTable(
     session_state: text("session_state"),
   },
   (account) => ({
-    compoundKey: primaryKey(account.provider, account.providerAccountId),
+    compoundKey: primaryKey({
+      columns: [account.provider, account.providerAccountId],
+    }),
   })
 );
 
@@ -425,7 +430,7 @@ export const verificationTokens = sqliteTable(
     expires: integer("expires", { mode: "timestamp_ms" }).notNull(),
   },
   (vt) => ({
-    compoundKey: primaryKey(vt.identifier, vt.token),
+    compoundKey: primaryKey({ columns: [vt.identifier, vt.token] }),
   })
 );`;
     default:

--- a/src/commands/add/misc/stripe/generators.ts
+++ b/src/commands/add/misc/stripe/generators.ts
@@ -975,7 +975,7 @@ export const subscriptions = pgTable(
   },
   (table) => {
     return {
-      pk: primaryKey(table.userId, table.stripeCustomerId),
+      pk: primaryKey({ columns: [table.userId, table.stripeCustomerId] }),
     };
   }
 );
@@ -1001,7 +1001,7 @@ export const subscriptions = mysqlTable(
   },
   (table) => {
     return {
-      pk: primaryKey(table.userId, table.stripeCustomerId),
+      pk: primaryKey({ columns: [table.userId, table.stripeCustomerId] }),
     };
   }
 );
@@ -1034,7 +1034,7 @@ export const subscriptions = sqliteTable(
   },
   (table) => {
     return {
-      pk: primaryKey(table.userId, table.stripeCustomerId),
+      pk: primaryKey({ columns: [table.userId, table.stripeCustomerId] }),
     };
   }
 );


### PR DESCRIPTION
Drizzle updated the syntax to use when declaring primary keys.

noted in the [0.29.0 release notes](https://github.com/drizzle-team/drizzle-orm/releases#:~:text=%F0%9F%8E%89%20Possibility%20to%20specify%20name%20for%20primary%20keys%20and%20foreign%20keys)