### PR TITLE
Drizzle multi project schema

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   execa:
     specifier: ^8.0.1
     version: 8.0.1
+  pluralize:
+    specifier: ^8.0.0
+    version: 8.0.0
   strip-json-comments:
     specifier: ^5.0.1
     version: 5.0.1
@@ -1066,6 +1069,11 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
     dev: true
+
+  /pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+    dev: false
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}

--- a/src/commands/add/auth/next-auth/generators.ts
+++ b/src/commands/add/auth/next-auth/generators.ts
@@ -272,7 +272,9 @@ export const accounts = pgTable(
     session_state: text("session_state"),
   },
   (account) => ({
-    compoundKey: primaryKey(account.provider, account.providerAccountId),
+    compoundKey: primaryKey({
+      columns: [account.provider, account.providerAccountId],
+    }),
   })
 );
 
@@ -292,7 +294,7 @@ export const verificationTokens = pgTable(
     expires: timestamp("expires", { mode: "date" }).notNull(),
   },
   (vt) => ({
-    compoundKey: primaryKey(vt.identifier, vt.token),
+    compoundKey: primaryKey({ columns: [vt.identifier, vt.token] }),
   })
 );
 `;
@@ -344,8 +346,9 @@ export const accounts = mysqlTable(
     session_state: varchar("session_state", { length: 255 }),
   },
   (account) => ({
-    compoundKey: primaryKey(account.provider, account.providerAccountId),
-  })
+    compoundKey: primaryKey({
+      columns: [account.provider, account.providerAccountId],
+    }),
 );
 
 export const sessions = mysqlTable("session", {
@@ -367,7 +370,7 @@ export const verificationTokens = mysqlTable(
     expires: timestamp("expires", { mode: "date" }).notNull(),
   },
   (vt) => ({
-    compoundKey: primaryKey(vt.identifier, vt.token),
+    compoundKey: primaryKey({ columns: [vt.identifier, vt.token] }),
   })
 );`;
     case "sqlite":
@@ -405,7 +408,9 @@ export const accounts = sqliteTable(
     session_state: text("session_state"),
   },
   (account) => ({
-    compoundKey: primaryKey(account.provider, account.providerAccountId),
+    compoundKey: primaryKey({
+      columns: [account.provider, account.providerAccountId],
+    }),
   })
 );
 
@@ -425,7 +430,7 @@ export const verificationTokens = sqliteTable(
     expires: integer("expires", { mode: "timestamp_ms" }).notNull(),
   },
   (vt) => ({
-    compoundKey: primaryKey(vt.identifier, vt.token),
+    compoundKey: primaryKey({ columns: [vt.identifier, vt.token] }),
   })
 );`;
     default:

--- a/src/commands/add/misc/stripe/generators.ts
+++ b/src/commands/add/misc/stripe/generators.ts
@@ -944,6 +944,8 @@ export const generateSubscriptionsDrizzleSchema = (
   driver: DBType,
   auth: AuthType,
 ) => {
+  const { multiProjectSchema } = readConfigFile();
+  const { drizzle } = getFilePaths();
   const authSubtype = AuthSubTypeMapping[auth];
   // add references for pg and sqlite
   switch (driver) {
@@ -981,12 +983,16 @@ export const subscriptions = pgTable(
 );
 `;
     case "mysql":
-      return `import {
-  mysqlTable,
+      return `import {${multiProjectSchema === true ? "" : "\n  mysqlTable,"}
   primaryKey,
   timestamp,
   varchar,
 } from "drizzle-orm/mysql-core";
+${multiProjectSchema === true ? 'import { mysqlTable } from "' + 
+formatFilePath(drizzle.dbIndex, {
+  prefix: "alias",
+  removeExtension: true,
+}) + '";' : ""}
 
 export const subscriptions = mysqlTable(
   "subscriptions",

--- a/src/commands/add/misc/stripe/generators.ts
+++ b/src/commands/add/misc/stripe/generators.ts
@@ -975,7 +975,7 @@ export const subscriptions = pgTable(
   },
   (table) => {
     return {
-      pk: primaryKey(table.userId, table.stripeCustomerId),
+      pk: primaryKey({ columns: [table.userId, table.stripeCustomerId] }),
     };
   }
 );
@@ -1001,7 +1001,7 @@ export const subscriptions = mysqlTable(
   },
   (table) => {
     return {
-      pk: primaryKey(table.userId, table.stripeCustomerId),
+      pk: primaryKey({ columns: [table.userId, table.stripeCustomerId] }),
     };
   }
 );
@@ -1034,7 +1034,7 @@ export const subscriptions = sqliteTable(
   },
   (table) => {
     return {
-      pk: primaryKey(table.userId, table.stripeCustomerId),
+      pk: primaryKey({ columns: [table.userId, table.stripeCustomerId] }),
     };
   }
 );

--- a/src/commands/add/orm/drizzle/index.ts
+++ b/src/commands/add/orm/drizzle/index.ts
@@ -52,6 +52,16 @@ export const addDrizzle = async (initOptions?: InitOptions) => {
       ],
     })) as DBType);
 
+  const multiProjectSchema = (await select({
+    message: "Are you using a multi-project schema?",
+    choices: [
+      { name: "No", value: false },
+      { name: "Yes", value: true },
+    ],
+  })) as boolean;
+
+  console.log("\n\n\n\n\n\nMULTI PROJECT SCHEMA", multiProjectSchema);
+
   // const dbProviders = DBProviders[dbType].filter((p) => {
   //   if (preferredPackageManager === "bun") return p.value !== "better-sqlite3";
   //   else return p.value !== "bun-sqlite";
@@ -97,6 +107,13 @@ export const addDrizzle = async (initOptions?: InitOptions) => {
     createFolder(`${hasSrc ? "src/" : ""}lib/api`);
   }
 
+  updateConfigFile({
+    driver: dbType,
+    provider: dbProvider,
+    orm: "drizzle",
+    multiProjectSchema,
+  });
+
   // dependent on dbtype and driver, create
   createIndexTs(dbProvider);
   createMigrateTs(libPath, dbType, dbProvider);
@@ -124,8 +141,6 @@ export const addDrizzle = async (initOptions?: InitOptions) => {
       rootPath
     );
   await updateTsConfigTarget();
-
-  updateConfigFile({ driver: dbType, provider: dbProvider, orm: "drizzle" });
   await installDependencies(dbProvider, preferredPackageManager);
   addPackageToConfig("drizzle");
 };

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -72,6 +72,7 @@ export async function initProject(options?: InitOptions) {
     packages: [],
     preferredPackageManager,
     orm: undefined,
+    multiProjectSchema: undefined,
     auth: undefined,
     componentLib: undefined,
     t3: false,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -89,6 +89,7 @@ export type Config = {
   provider: DBProvider | null;
   packages: AvailablePackage[];
   orm: ORMType | null;
+  multiProjectSchema: boolean | null;
   auth: AuthType | null;
   componentLib: ComponentLibType | null;
   t3: boolean;


### PR DESCRIPTION
DRAFT

I implemented a setup for [Drizzle's "multi-project schema"](https://orm.drizzle.team/docs/goodies#multi-project-schema) on my happy path:
- drizzle
- mysql
- planetscale

Basically, creates `mysqlTable` function in the `src/lib/db/index` file using the syntax for multi-project schema.  Then, depending on the user's choice from the cli, will either import `mysqlTable` from drizzle directly or import it from our specifically created function.

Not sure if this is the best way to implement this in this repo, as im not too familiar. But after playing around in here for the first time today, this was the first modification i made so figured i'd put this up as a draft. If its something others are interested in, i can look into implementing for pg + sqlite.