### PR TITLE
Add resend webhook api handler

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   execa:
     specifier: ^8.0.1
     version: 8.0.1
+  pluralize:
+    specifier: ^8.0.0
+    version: 8.0.0
   strip-json-comments:
     specifier: ^5.0.1
     version: 5.0.1
@@ -1066,6 +1069,11 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
     dev: true
+
+  /pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+    dev: false
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}

--- a/src/commands/add/misc/resend/index.ts
+++ b/src/commands/add/misc/resend/index.ts
@@ -27,6 +27,7 @@ export const addResend = async (packagesBeingInstalled: AvailablePackage[]) => {
     generateEmailIndexTs,
     generateApiRoute,
     generateEmailTemplateComponent,
+    generateWebhooksApiRoute,
   } = resendGenerators;
 
   // 1. Add page at app/resend/page.tsx
@@ -73,12 +74,29 @@ export const addResend = async (packagesBeingInstalled: AvailablePackage[]) => {
     generateEmailIndexTs()
   );
 
-  // 6. Add items to .env
-  addToDotEnv([{ key: "RESEND_API_KEY", value: "" }], rootPath, true);
-  // 7. Install packages (resend)
+  // 6. Add webhook handler at app/api/webhooks/resend/route.ts
+  createFile(
+    formatFilePath(resend.resendWebhooksApiRoute, {
+      prefix: "rootPath",
+      removeExtension: false,
+    }),
+    generateWebhooksApiRoute()
+  );
+
+  // 7. Add items to .env
+  addToDotEnv(
+    [
+      { key: "RESEND_API_KEY", value: "" },
+      { key: "RESEND_WEBHOOK_SECRET", value: "whsec..." },
+    ],
+    rootPath,
+    true
+  );
+
+  // 8. Install packages (resend)
   await installPackages(
     {
-      regular: `resend${orm === null ? " zod @t3-oss/env-nextjs" : ""}`,
+      regular: `resend${orm === null ? " zod @t3-oss/env-nextjs" : ""} svix`,
       dev: "",
     },
     preferredPackageManager

--- a/src/commands/filePaths/index.ts
+++ b/src/commands/filePaths/index.ts
@@ -69,6 +69,7 @@ export const paths: { t3: Paths; normal: Paths } = {
       emailApiRoute: "app/api/email/route.ts",
       libEmailIndex: "lib/email/index.ts",
       firstEmailComponent: "components/emails/FirstEmail.tsx",
+      resendWebhooksApiRoute: "app/api/webhooks/resend/route.ts",
     },
     stripe: {
       stripeIndex: "lib/stripe/index.ts",
@@ -159,6 +160,7 @@ export const paths: { t3: Paths; normal: Paths } = {
       emailApiRoute: "app/api/email/route.ts",
       libEmailIndex: "lib/email/index.ts",
       firstEmailComponent: "components/emails/FirstEmail.tsx",
+      resendWebhooksApiRoute: "app/api/webhooks/resend/route.ts",
     },
     stripe: {
       stripeIndex: "lib/stripe/index.ts",

--- a/src/commands/filePaths/types.d.ts
+++ b/src/commands/filePaths/types.d.ts
@@ -84,5 +84,6 @@ export type Paths = {
     emailApiRoute: string;
     emailUtils: string;
     libEmailIndex: string;
+    resendWebhooksApiRoute: string;
   };
 };


### PR DESCRIPTION
Add an api handler for resend webhooks.

- create new file `/app/api/webhooks/resend/route.ts`
- add types for Resend webhook events
- install and use `svix` package to ensure valid POSTs to this endpoint
- new environment variable `RESEND_WEBOOK_SECRET` to be used in combination with the svix package
