### PR TITLE
Fix prisma schema for NextAuth.js with GitHub login

### DIFF
--- a/src/commands/add/auth/next-auth/generators.ts
+++ b/src/commands/add/auth/next-auth/generators.ts
@@ -586,6 +586,7 @@ export const enableSessionInTRPCApi_DEPRECATED = () => {
 export const createPrismaAuthSchema = (
   driver: DBType,
   usingPlanetScale: boolean,
+  usingNextAuthGitHub: boolean
 ) => {
   return `model Account {
   id                 String  @id @default(cuid())
@@ -600,6 +601,8 @@ export const createPrismaAuthSchema = (
   scope              String?
   id_token           String?  ${driver !== "sqlite" ? "@db.Text" : ""}
   session_state      String?
+
+  ${usingNextAuthGitHub ? "refresh_token_expires_in Int?" : ""}
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 

--- a/src/commands/add/auth/next-auth/index.ts
+++ b/src/commands/add/auth/next-auth/index.ts
@@ -95,8 +95,8 @@ export const addNextAuth = async (options?: InitOptions) => {
     }
     if (orm === "prisma") {
       addToPrismaSchema(
-        createPrismaAuthSchema(driver, dbProvider === "planetscale"),
-        "Auth",
+        createPrismaAuthSchema(driver, dbProvider === "planetscale", providers.includes("github")),
+        "Auth"
       );
     }
   }


### PR DESCRIPTION
Fixes #95:

https://next-auth.js.org/providers/github

GitHub returns a field on Account called refresh_token_expires_in which is a number. See their docs. Remember to add this field to your database schema, in case if you are using an Adapter.