### PR TITLE
feat: add turso as a sqlite db provider

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   execa:
     specifier: ^8.0.1
     version: 8.0.1
+  pluralize:
+    specifier: ^8.0.0
+    version: 8.0.0
   strip-json-comments:
     specifier: ^5.0.1
     version: 5.0.1
@@ -1066,6 +1069,11 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
     dev: true
+
+  /pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
+    dev: false
 
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}

--- a/src/commands/add/orm/drizzle/index.ts
+++ b/src/commands/add/orm/drizzle/index.ts
@@ -45,7 +45,7 @@ export const addDrizzle = async (initOptions?: InitOptions) => {
           disabled:
             preferredPackageManager === "bun"
               ? wrapInParenthesis(
-                  "Drizzle Kit doesn't support SQLite with Bun yet"
+                  "Drizzle Kit doesn't support SQLite with Bun yet",
                 )
               : false,
         },
@@ -109,7 +109,7 @@ export const addDrizzle = async (initOptions?: InitOptions) => {
     preferredPackageManager,
     databaseUrl,
     dbProvider === "planetscale",
-    hasSrc ? "src/" : ""
+    hasSrc ? "src/" : "",
   );
   if (dbProvider === "vercel-pg")
     addToDotEnv(
@@ -121,8 +121,10 @@ export const addDrizzle = async (initOptions?: InitOptions) => {
         { key: "POSTGRES_PASSWORD", value: "" },
         { key: "POSTGRES_DATABASE", value: "" },
       ],
-      rootPath
+      rootPath,
     );
+  if (dbProvider === "turso")
+    addToDotEnv([{ key: "DATABASE_AUTH_TOKEN", value: "" }], rootPath);
   await updateTsConfigTarget();
 
   updateConfigFile({ driver: dbType, provider: dbProvider, orm: "drizzle" });

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -20,7 +20,7 @@ export async function initProject(options?: InitOptions) {
   const nextjsProjectExists = existsSync("package.json");
   if (!nextjsProjectExists) {
     consola.fatal(
-      "No Next.js project detected. Please create a Next.js project and then run `kirimase init` within that directory."
+      "No Next.js project detected. Please create a Next.js project and then run `kirimase init` within that directory.",
     );
     process.exit(0);
   }

--- a/src/commands/init/utils.ts
+++ b/src/commands/init/utils.ts
@@ -36,6 +36,7 @@ export const DBProviders: DBProviderOptions = {
   ],
   sqlite: [
     { name: "better-sqlite3", value: "better-sqlite3" },
+    { name: "turso", value: "turso" },
     // { name: "Bun SQLite", value: "bun-sqlite" },
   ],
 };
@@ -121,6 +122,7 @@ export const checkForExistingPackages = async (rootPath: string) => {
     "vercel-pg": "@vercel/postgres",
     planetscale: "@planetscale/database",
     "better-sqlite3": "better-sqlite3",
+    turso: "@libsql/client",
   };
   const providerDriverMappings: Record<DBProvider, DBType> = {
     aws: "pg",
@@ -132,6 +134,7 @@ export const checkForExistingPackages = async (rootPath: string) => {
     "vercel-pg": "pg",
     planetscale: "mysql",
     "better-sqlite3": "sqlite",
+    turso: "sqlite",
   };
   for (const [key, term] of Object.entries(providerMappings)) {
     // console.log(key, terms);

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -20,7 +20,8 @@ export type DBProvider =
   | "aws"
   | "planetscale"
   | "mysql-2"
-  | "better-sqlite3";
+  | "better-sqlite3"
+  | "turso";
 // | "bun-sqlite";
 
 export type DBProviderOptions = {


### PR DESCRIPTION
This adds the turso provider to kirimase init. 

![image](https://github.com/nicoalbanese/kirimase/assets/114683794/18c13971-672c-4392-a167-e69a3a01d2d4)

The migrator, db client, env variables, and drizzle config have been configured to support turso for sqlite.