### PR TITLE
[Fix] Check is auth prompt is undefined

### DIFF
--- a/src/commands/add/index.ts
+++ b/src/commands/add/index.ts
@@ -177,7 +177,7 @@ export const addPackage = async (options?: InitOptions) => {
     }
     // check if auth
     if (config.auth === undefined) {
-      if (promptResponse.auth !== null)
+      if (promptResponse.auth && promptResponse.auth !== null)
         spinner.text =
           "Configuring " +
           promptResponse.auth[0].toUpperCase() +
@@ -188,7 +188,7 @@ export const addPackage = async (options?: InitOptions) => {
       if (promptResponse.auth === "clerk") await addClerk();
       if (promptResponse.auth === "lucia") await addLucia();
       if (promptResponse.auth === "kinde") await addKinde();
-      if (promptResponse.auth === null) {
+      if (!promptResponse.auth) {
         replaceFile(
           formatFilePath("app/page.tsx", {
             prefix: "rootPath",


### PR DESCRIPTION
Should fix the error described below which occurs during `kirisame init` when no ORM (and subsequently no auth) is provided. 
Previously code was checking for value of `promptResponse.auth !== null`, which is true for `undefined` (Thanks, JavaScript). 
This should prevent the `init` command from crashing when selecting no ORM and no Auth 🤞 

**Config File**
```
{
  "hasSrc": false,
  "packages": [
    "shadcn-ui"
  ],
  "preferredPackageManager": "pnpm",
  "t3": false,
  "alias": "@",
  "rootPath": "",
  "componentLib": "shadcn-ui"
}%
```

**Describe the bug**
`kirisame init` throwing the following error on a new project;

```
⠋ file:///Users/jason/Library/pnpm/global/5/.pnpm/kirimase@0.0.44/node_modules/kirimase/dist/commands/add/index.js:122
                        promptResponse.auth[0].toUpperCase() +
                                           ^

TypeError: Cannot read properties of undefined (reading '0')
    at addPackage (file:///Users/jason/Library/pnpm/global/5/.pnpm/kirimase@0.0.44/node_modules/kirimase/dist/commands/add/index.js:122:44)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v20.5.1
```

**To Reproduce**
Steps to reproduce the behavior:

```
➜  ~ cd Code/open-source
Found '/Users/jason/Code/open-source/.nvmrc' with version <20.5.1>
Now using node v20.5.1 (npm v9.8.0)
➜  open-source pnpx create-next-app@latest
Packages: +1
+
Progress: resolved 1, reused 1, downloaded 0, added 1, done
✔ What is your project named? … kirimase-bug-demo
✔ Would you like to use TypeScript? … No / Yes (Yes)
✔ Would you like to use ESLint? … No / Yes (Yes)
✔ Would you like to use Tailwind CSS? … No / Yes (Yes)
✔ Would you like to use `src/` directory? … No / Yes (No)
✔ Would you like to use App Router? (recommended) … No / Yes (Yes)
✔ Would you like to customize the default import alias (@/*)? … No / Yes (No)
Creating a new Next.js app in /Users/jason/Code/open-source/kirimase-bug-demo.

Using pnpm.

Initializing project with template: app-tw

Installing dependencies:
- react
- react-dom
- next

Installing devDependencies:
- typescript
- @types/node
- @types/react
- @types/react-dom
- autoprefixer
- postcss
- tailwindcss
- eslint
- eslint-config-next

Packages: +350
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 358, reused 350, downloaded 0, added 350, done

dependencies:
+ next 14.0.4
+ react 18.2.0
+ react-dom 18.2.0

devDependencies:
+ @types/node 20.11.5
+ @types/react 18.2.48
+ @types/react-dom 18.2.18
+ autoprefixer 10.4.17
+ eslint 8.56.0
+ eslint-config-next 14.0.4
+ postcss 8.4.33
+ tailwindcss 3.4.1
+ typescript 5.3.3

Done in 3.8s
Initialized a git repository.

Success! Created kirimase-bug-demo at /Users/jason/Code/open-source/kirimase-bug-demo

➜  open-source cd kirimase-bug-demo
➜  kirimase-bug-demo git:(main) kirimase init
✔ Kirimase initialized!                                            3:34:21 PM
ℹ You can now add packages.                                        3:34:21 PM
◐ Checking project for existing packages...                         3:34:21 PM
✔ Successfully searched project and found no additional packages.  3:34:21 PM
? Select a component library to use: Shadcn UI (with next-themes)
? Select an ORM to use: None
? Are you sure you don't want to install an ORM? Note: you will not be able to
install any auth. yes
? Select any miscellaneous packages to add: TRPC, Stripe
⠋ file:///Users/jason/Library/pnpm/global/5/.pnpm/kirimase@0.0.44/node_modules/kirimase/dist/commands/add/index.js:122
                        promptResponse.auth[0].toUpperCase() +
                                           ^

TypeError: Cannot read properties of undefined (reading '0')
    at addPackage (file:///Users/jason/Library/pnpm/global/5/.pnpm/kirimase@0.0.44/node_modules/kirimase/dist/commands/add/index.js:122:44)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v20.5.1
```


**Expected behavior**
Expecting the typeError is not thrown

**Screenshots**
n/a

**Desktop (please complete the following information):**
 - MacOS v14.2.1
 - kirisame v0.0.44
 - Node v20.5.1

**Additional context**
n/a