### PR TITLE
50 migrate to sonner

### DIFF
--- a/src/commands/add/auth/shared/generators.ts
+++ b/src/commands/add/auth/shared/generators.ts
@@ -38,12 +38,11 @@ export const createUpdateNameCard = (withShadCn = false, disabled = false) => {
 import { AccountCard, AccountCardFooter, AccountCardBody } from "./AccountCard";
 import { Button } from "${alias}/components/ui/button";
 import { Input } from "${alias}/components/ui/input";
-import { useToast } from "${alias}/components/ui/use-toast";
+import { toast } from "sonner";
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 export default function UpdateNameCard({ name }: { name: string }) {
-  const { toast } = useToast();
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
   const handleSubmit = async (event: React.SyntheticEvent) => {
@@ -52,10 +51,7 @@ export default function UpdateNameCard({ name }: { name: string }) {
     const form = new FormData(target);
     const { name } = Object.fromEntries(form.entries()) as { name: string };
     if (name.length < 3) {
-      toast({
-        description: "Name must be longer than 3 characters.",
-        variant: "destructive",
-      });
+      toast.error("Name must be longer than 3 characters.");
       return;
     }
 
@@ -66,7 +62,7 @@ export default function UpdateNameCard({ name }: { name: string }) {
         headers: { "Content-Type": "application/json" },
       });
       if (res.status === 200)
-        toast({ description: "Successfully updated name!" });
+        toast.success("Successfully updated name!");
       router.refresh();
     });
   };
@@ -160,12 +156,11 @@ export const createUpdateEmailCard = (withShadCn = false, disabled = false) => {
     return `import { AccountCard, AccountCardFooter, AccountCardBody } from "./AccountCard";
 import { Button } from "${alias}/components/ui/button";
 import { Input } from "${alias}/components/ui/input";
-import { useToast } from "${alias}/components/ui/use-toast";
+import { toast } from "sonner";
 import { useTransition } from "react";
 import { useRouter } from "next/navigation";
 
 export default function UpdateEmailCard({ email }: { email: string }) {
-  const { toast } = useToast();
   const [isPending, startTransition] = useTransition();
   const router = useRouter();
 
@@ -175,10 +170,7 @@ export default function UpdateEmailCard({ email }: { email: string }) {
     const form = new FormData(target);
     const { email } = Object.fromEntries(form.entries()) as { email: string };
     if (email.length < 3) {
-      toast({
-        description: "Email must be longer than 3 characters.",
-        variant: "destructive",
-      });
+      toast.error("Email must be longer than 3 characters.");
       return;
     }
 
@@ -189,7 +181,7 @@ export default function UpdateEmailCard({ email }: { email: string }) {
         headers: { "Content-Type": "application/json" },
       });
       if (res.status === 200)
-        toast({ description: "Successfully updated email!" });
+        toast.success("Successfully updated email!");
       router.refresh();
     });
   };

--- a/src/commands/add/componentLib/shadcn-ui/index.ts
+++ b/src/commands/add/componentLib/shadcn-ui/index.ts
@@ -131,7 +131,7 @@ export const installShadcnUI = async (
   // ]);
   addToShadcnComponentList([
     "button",
-    "toast",
+    "sonner",
     "avatar",
     "input",
     "label",

--- a/src/commands/add/misc/stripe/generators.ts
+++ b/src/commands/add/misc/stripe/generators.ts
@@ -307,7 +307,7 @@ export const generateManageSubscriptionButton = () => {
 
 import { Button } from "${alias}/components/ui/button";
 import React from "react";
-import { toast } from "${alias}/components/ui/use-toast";
+import { toast } from "sonner";
 import { Loader2 } from "lucide-react";
 
 interface ManageUserSubscriptionButtonProps {
@@ -352,7 +352,7 @@ export function ManageUserSubscriptionButton({
         }
       } catch (err) {
         console.error((err as Error).message);
-        toast({ description: "Something went wrong, please try again later." });
+        toast.error("Something went wrong, please try again later.");
       }
     });
   };
@@ -448,18 +448,17 @@ export const generateSuccessToast = () => {
   const { alias } = readConfigFile();
   return `"use client";
 
-import { useToast } from "${alias}/components/ui/use-toast";
+import { toast } from "sonner";
 import { useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
 export default function SuccessToast() {
   const searchParams = useSearchParams();
-  const { toast } = useToast();
 
   const success = searchParams.get("success") as Boolean | null;
   useEffect(() => {
     if (success) {
-      toast({ description: "Successfully updated subscription." });
+      toast.success("Successfully updated subscription.");
     }
   }, [success, toast]);
 

--- a/src/commands/add/utils.ts
+++ b/src/commands/add/utils.ts
@@ -82,7 +82,7 @@ export const addContextProviderToLayout = (
       )}";\nimport { cookies } from "next/headers";`;
       break;
     case "ShadcnToast":
-      importStatement = `import { Toaster } from "${alias}/components/ui/toaster";`;
+      importStatement = `import { Toaster } from "${alias}/components/ui/sonner";`;
       break;
     case "ClerkProvider":
       importStatement = 'import { ClerkProvider } from "@clerk/nextjs";';
@@ -115,7 +115,7 @@ export const addContextProviderToLayout = (
   let replacementText = "";
   switch (provider) {
     case "ShadcnToast":
-      replacementText = `${rootChildrenText}\n<Toaster />\n`;
+      replacementText = `${rootChildrenText}\n<Toaster richColors />\n`;
       break;
     case "Navbar":
       replacementText = `<div className="flex h-screen">\n<Sidebar />\n<main className="flex-1 md:p-8 pt-2 p-8 overflow-y-auto">\n<Navbar />\n{children}\n</main>\n</div>`;

--- a/src/commands/generate/generators/model/schema/index.ts
+++ b/src/commands/generate/generators/model/schema/index.ts
@@ -221,7 +221,8 @@ const generateTimestampFieldsDrizzle = () => {
   const config = readConfigFile();
   switch (config.driver) {
     case "pg":
-      schemaContent = `  createdAt: timestamp("created_at")
+      schemaContent = `,
+  createdAt: timestamp("created_at")
     .notNull()
     .default(sql\`now()\`),
   updatedAt: timestamp("updated_at")
@@ -231,7 +232,8 @@ const generateTimestampFieldsDrizzle = () => {
       importType = "timestamp";
       break;
     case "mysql":
-      schemaContent = `  createdAt: timestamp("created_at")
+      schemaContent = `,
+  createdAt: timestamp("created_at")
     .notNull()
     .default(sql\`now()\`),
   updatedAt: timestamp("updated_at")
@@ -241,7 +243,8 @@ const generateTimestampFieldsDrizzle = () => {
       importType = "timestamp";
       break;
     case "sqlite":
-      schemaContent = `  createdAt: text("created_at")
+      schemaContent = `,
+  createdAt: text("created_at")
     .notNull()
     .default(sql\`CURRENT_TIMESTAMP\`),
   updatedAt: text("updated_at")

--- a/src/commands/generate/generators/views-with-server-actions.ts
+++ b/src/commands/generate/generators/views-with-server-actions.ts
@@ -746,10 +746,7 @@ const createFormComponent = (schema: Schema) => {
 import { useState, useTransition } from "react";
 import { useFormStatus } from "react-dom";
 import { useRouter } from "next/navigation";
-import { useToast } from "${formatFilePath(`components/ui/use-toast`, {
-    prefix: "alias",
-    removeExtension: false,
-  })}";
+import { toast } from "sonner";
 import { useValidatedForm } from "${formatFilePath(
     `lib/hooks/useValidatedForm.tsx`,
     { prefix: "alias", removeExtension: true }
@@ -827,7 +824,6 @@ const ${tableNameSingularCapitalised}Form = ({${
 }) => {
   const { errors, hasErrors, setErrors, handleChange } =
     useValidatedForm<${tableNameSingularCapitalised}>(insert${tableNameSingularCapitalised}Params);
-  const { toast } = useToast();
   const editing = !!${tableNameSingular}?.id;
   ${
     dateFields.length > 0
@@ -855,16 +851,12 @@ const ${tableNameSingularCapitalised}Form = ({${
     const failed = Boolean(data?.error);
     if (failed) {
       openModal && openModal(data?.values);
+      toast.error(data?.error ?? "Error")
     } else {
       router.refresh();
       postSuccess && postSuccess();
+      toast.success(\`${tableNameSingularCapitalised} \${action}d!\`);
     }
-
-    toast({
-      title: failed ? \`Failed to \${action}\` : "Success",
-      description: failed ? data?.error ?? "Error" : \`${tableNameSingularCapitalised} \${action}d!\`,
-      variant: failed ? "destructive" : "default",
-    });
   };
 
   const handleSubmit = async (data: FormData) => {

--- a/src/commands/generate/generators/views.ts
+++ b/src/commands/generate/generators/views.ts
@@ -377,7 +377,7 @@ import { format } from "date-fns";`
   }
 import { useRouter } from "next/navigation";${
     packages.includes("shadcn-ui")
-      ? `\nimport { useToast } from "${alias}/components/ui/use-toast";`
+      ? `\nimport { toast } from "sonner";`
       : ""
   }
 
@@ -387,9 +387,7 @@ const ${tableNameSingularCapitalised}Form = ({
 }: {
   ${tableNameSingular}?: ${tableNameSingularCapitalised};
   closeModal?: () => void;
-}) => {${
-    packages.includes("shadcn-ui") ? `\n  const { toast } = useToast();` : ""
-  }
+}) => {
   ${
     relations.length > 0
       ? relations
@@ -426,14 +424,7 @@ const ${tableNameSingularCapitalised}Form = ({
   }    data?: { error?: string },
   ) => {
         if (data?.error) {
-      toast({
-        title: \`\${action
-          .slice(0, 1)
-          .toUpperCase()
-          .concat(action.slice(1))} Failed\`,
-        description: data.error,
-        variant: "destructive",
-      });
+      toast.error(data.error)
       return;
     }
 
@@ -441,11 +432,7 @@ const ${tableNameSingularCapitalised}Form = ({
     router.refresh();
     if (closeModal) closeModal();${
       packages.includes("shadcn-ui")
-        ? `\n        toast({
-      title: 'Success',
-      description: \`${tableNameNormalEnglishSingular} \${action}d!\`,
-      variant: "default",
-    });`
+        ? `\n        toast.success(\`${tableNameNormalEnglishSingular} \${action}d!\`);`
         : null
     }
   };
@@ -455,6 +442,9 @@ const ${tableNameSingularCapitalised}Form = ({
       onSuccess${
         packages.includes("shadcn-ui") ? ': (res) => onSuccess("create")' : ""
       },
+      onError${
+        packages.includes("shadcn-ui") ? ': (err) => onError("create", { error: err.message })' : ""
+      },
     });
 
   const { mutate: update${tableNameSingularCapitalised}, isLoading: isUpdating } =
@@ -462,12 +452,18 @@ const ${tableNameSingularCapitalised}Form = ({
       onSuccess${
         packages.includes("shadcn-ui") ? ': (res) => onSuccess("update")' : ""
       },
+      onError${
+        packages.includes("shadcn-ui") ? ': (err) => onError("update", { error: err.message })' : ""
+      },
     });
 
   const { mutate: delete${tableNameSingularCapitalised}, isLoading: isDeleting } =
     trpc.${tableNameCamelCase}.delete${tableNameSingularCapitalised}.useMutation({
       onSuccess${
         packages.includes("shadcn-ui") ? ': (res) => onSuccess("delete")' : ""
+      },
+      onError${
+        packages.includes("shadcn-ui") ? ': (err) => onError("delete", { error: err.message })' : ""
       },
     });
 


### PR DESCRIPTION
## What changed
This closes #50 .
[] migrates to use sonner instead of react toast in both TRPC and server actions
[] adds an onError callback for trpc actions to trigger sonner toast
[] fixes a small template issue when generating timestamps in the schema files

## To test
Generate a new next app, kirimase init, kirimase generate, and then perform a CRUD action
