### PR TITLE
Adds Supabase as Auth Provider + Prettier format for the generated files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kirimase",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "A Rails-like CLI for building full-stack Next.js apps faster",
   "main": "index.js",
   "type": "module",
@@ -41,6 +41,7 @@
     "@typescript-eslint/eslint-plugin": "^6.6.0",
     "@typescript-eslint/parser": "^6.6.0",
     "eslint": "^8.48.0",
+    "prettier": "^3.2.5",
     "typescript": "^5.1.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ devDependencies:
   eslint:
     specifier: ^8.48.0
     version: 8.48.0
+  prettier:
+    specifier: ^3.2.5
+    version: 3.2.5
   typescript:
     specifier: ^5.1.6
     version: 5.1.6
@@ -1174,6 +1177,12 @@ packages:
   /prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+    dev: true
+
+  /prettier@3.2.5:
+    resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
+    engines: {node: '>=14'}
+    hasBin: true
     dev: true
 
   /punycode@2.3.0:

--- a/src/commands/add/auth/clerk/index.ts
+++ b/src/commands/add/auth/clerk/index.ts
@@ -6,11 +6,9 @@
 // 6. Add lib/auth/utils.ts
 // 7. install package - @clerk/nextjs
 
-import { consola } from "consola";
 import {
   addPackageToConfig,
   createFile,
-  installPackages,
   readConfigFile,
   replaceFile,
   updateConfigFile,
@@ -23,11 +21,10 @@ import {
 } from "../../utils.js";
 import { clerkGenerators } from "./generators.js";
 import { formatFilePath, getFilePaths } from "../../../filePaths/index.js";
-import { libAuthUtilsTs } from "../next-auth/generators.js";
 import { updateTrpcWithSessionIfInstalled } from "../shared/index.js";
 
 export const addClerk = async () => {
-  const { rootPath, preferredPackageManager, componentLib } = readConfigFile();
+  const { rootPath, componentLib } = readConfigFile();
   const {
     clerk: { middleware, signInPage, signUpPage },
     shared: {
@@ -35,6 +32,7 @@ export const addClerk = async () => {
       init,
     },
   } = getFilePaths();
+
   const {
     generateAuthUtilsTs,
     generateMiddlewareTs,
@@ -42,9 +40,11 @@ export const addClerk = async () => {
     generateSignUpPageTs,
     homePageWithUserButton,
   } = clerkGenerators;
-  addContextProviderToAuthLayout("ClerkProvider");
-  addContextProviderToAppLayout("ClerkProvider");
-  addToDotEnv(
+
+  await addContextProviderToAuthLayout("ClerkProvider");
+  await addContextProviderToAppLayout("ClerkProvider");
+
+  await addToDotEnv(
     [
       { key: "NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY", value: "", public: true },
       { key: "CLERK_SECRET_KEY", value: "" },
@@ -55,21 +55,21 @@ export const addClerk = async () => {
     ],
     rootPath
   );
-  createFile(
+  await createFile(
     formatFilePath(middleware, { prefix: "rootPath", removeExtension: false }),
     generateMiddlewareTs()
   );
 
-  createFile(
+  await createFile(
     formatFilePath(signInPage, { removeExtension: false, prefix: "rootPath" }),
     generateSignInPageTs()
   );
-  createFile(
+  await createFile(
     formatFilePath(signUpPage, { removeExtension: false, prefix: "rootPath" }),
     generateSignUpPageTs()
   );
 
-  replaceFile(
+  await replaceFile(
     formatFilePath(init.dashboardRoute, {
       removeExtension: false,
       prefix: "rootPath",
@@ -77,7 +77,7 @@ export const addClerk = async () => {
     homePageWithUserButton(componentLib)
   );
 
-  createFile(
+  await createFile(
     formatFilePath(authUtils, {
       prefix: "rootPath",
       removeExtension: false,
@@ -86,15 +86,15 @@ export const addClerk = async () => {
   );
 
   // If trpc installed, add protectedProcedure
-  updateTrpcWithSessionIfInstalled();
+  await updateTrpcWithSessionIfInstalled();
 
   addToInstallList({ regular: ["@clerk/nextjs"], dev: [] });
   // await installPackages(
   //   { regular: "@clerk/nextjs", dev: "" },
   //   preferredPackageManager,
   // );
-  addPackageToConfig("clerk");
-  updateConfigFile({ auth: "clerk" });
+  await addPackageToConfig("clerk");
+  await updateConfigFile({ auth: "clerk" });
   // consola.success("Successfully added Clerk to your project!");
   // consola.info(
   //   "Head over to https://dashboard.clerk.com/apps/new to create a new Clerk app"

--- a/src/commands/add/auth/clerk/utils.ts
+++ b/src/commands/add/auth/clerk/utils.ts
@@ -20,6 +20,7 @@ import { formatFilePath, getFilePaths } from "../../../filePaths/index.js";
 //   }
 // };
 
+// TODO: Shouldn't this be "matcher" instead of "ignoredRoutes"?
 export const addToClerkIgnoredRoutes = async (newPath: string) => {
   const { clerk } = getFilePaths();
   const initMWContent = "ignoredRoutes: [";

--- a/src/commands/add/auth/clerk/utils.ts
+++ b/src/commands/add/auth/clerk/utils.ts
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { createFile, replaceFile } from "../../../../utils.js";
+import { replaceFile } from "../../../../utils.js";
 import { formatFilePath, getFilePaths } from "../../../filePaths/index.js";
 
 // export const updateClerkMiddlewareForStripe = (rootPath: string) => {
@@ -14,13 +14,13 @@ import { formatFilePath, getFilePaths } from "../../../filePaths/index.js";
 //   if (mwExists) {
 //     const mwContent = fs.readFileSync(mwPath, "utf-8");
 //     const newUtilsContent = mwContent.replace(initMWContent, updatedMWContent);
-//     replaceFile(mwPath, newUtilsContent);
+//     await replaceFile(mwPath, newUtilsContent);
 //   } else {
 //     console.error("Middleware does not exist");
 //   }
 // };
 
-export const addToClerkIgnoredRoutes = (newPath: string) => {
+export const addToClerkIgnoredRoutes = async (newPath: string) => {
   const { clerk } = getFilePaths();
   const initMWContent = "ignoredRoutes: [";
   const updatedMWContent = "ignoredRoutes: [" + ` "${newPath}", `;
@@ -32,7 +32,7 @@ export const addToClerkIgnoredRoutes = (newPath: string) => {
   if (mwExists) {
     const mwContent = fs.readFileSync(mwPath, "utf-8");
     const newUtilsContent = mwContent.replace(initMWContent, updatedMWContent);
-    replaceFile(mwPath, newUtilsContent);
+    await replaceFile(mwPath, newUtilsContent);
   } else {
     console.error("Middleware does not exist");
   }

--- a/src/commands/add/auth/kinde/index.ts
+++ b/src/commands/add/auth/kinde/index.ts
@@ -1,8 +1,6 @@
-import { consola } from "consola";
 import {
   addPackageToConfig,
   createFile,
-  installPackages,
   readConfigFile,
   updateConfigFile,
 } from "../../../../utils.js";
@@ -20,33 +18,36 @@ import { addToInstallList } from "../../utils.js";
 
 export const addKinde = async () => {
   const { kinde, shared } = getFilePaths();
-  const { preferredPackageManager } = readConfigFile();
+
   // add api route
-  createFile(
+  await createFile(
     formatFilePath(kinde.routeHandler, {
       prefix: "rootPath",
       removeExtension: false,
     }),
     generateKindeRouteHandler()
   );
+
   // create signin button component
-  createFile(
+  await createFile(
     formatFilePath(shared.auth.signInComponent, {
       prefix: "rootPath",
       removeExtension: false,
     }),
     generateSignInComponent()
   );
+
   // create auth/utils.ts
-  createFile(
+  await createFile(
     formatFilePath(shared.auth.authUtils, {
       prefix: "rootPath",
       removeExtension: false,
     }),
     generateAuthUtils()
   );
+
   // update root page
-  createFile(
+  await createFile(
     formatFilePath(shared.init.dashboardRoute, {
       prefix: "rootPath",
       removeExtension: false,
@@ -55,7 +56,7 @@ export const addKinde = async () => {
   );
 
   // generate sign in page
-  createFile(
+  await createFile(
     formatFilePath(kinde.signInPage, {
       prefix: "rootPath",
       removeExtension: false,
@@ -64,10 +65,10 @@ export const addKinde = async () => {
   );
 
   // If trpc installed, add protectedProcedure
-  updateTrpcWithSessionIfInstalled();
+  await updateTrpcWithSessionIfInstalled();
 
   // add env variables
-  addToDotEnv([
+  await addToDotEnv([
     {
       key: "KINDE_CLIENT_ID",
       value: "",
@@ -91,7 +92,7 @@ export const addKinde = async () => {
   // );
   addToInstallList({ regular: ["@kinde-oss/kinde-auth-nextjs"], dev: [] });
 
-  addPackageToConfig("kinde");
-  updateConfigFile({ auth: "kinde" });
+  await addPackageToConfig("kinde");
+  await updateConfigFile({ auth: "kinde" });
   // consola.success("Successfully installed Kinde auth");
 };

--- a/src/commands/add/auth/lucia/generators.ts
+++ b/src/commands/add/auth/lucia/generators.ts
@@ -65,7 +65,7 @@ import { Label } from "${alias}/components/ui/label";
 
 const Page = async () => {
   return (
-    <main className="max-w-lg mx-auto my-4 bg-secondary p-10">
+    <main className="max-w-lg mx-auto my-4 bg-popover p-10">
       <h1 className="text-2xl font-bold text-center">Create an account</h1>
       <AuthForm action="/api/sign-up">
         <Label htmlFor="username" className="text-muted-foreground">
@@ -100,7 +100,7 @@ import Link from "next/link";
 
 const Page = async () => {
   return (
-    <main className="max-w-lg mx-auto my-4 bg-neutral-100 p-10">
+    <main className="max-w-lg mx-auto my-4 bg-white p-10">
       <h1 className="text-2xl font-bold text-center">Create an account</h1>
       <AuthForm action="/api/sign-up">
         <label
@@ -158,7 +158,7 @@ import Link from "next/link";
 
 const Page = async () => {
   return (
-    <main className="max-w-lg mx-auto my-4 bg-secondary p-10">
+    <main className="max-w-lg mx-auto my-4 bg-popover p-10">
       <h1 className="text-2xl font-bold text-center">
         Sign in to your account
       </h1>
@@ -198,7 +198,7 @@ import Link from "next/link";
 
 const Page = async () => {
   return (
-    <main className="max-w-lg mx-auto my-4 bg-neutral-100 p-10">
+    <main className="max-w-lg mx-auto my-4 bg-white p-10">
       <h1 className="text-2xl font-bold text-center">
         Sign in to your account
       </h1>

--- a/src/commands/add/auth/lucia/index.ts
+++ b/src/commands/add/auth/lucia/index.ts
@@ -1,12 +1,10 @@
 import {
   addPackageToConfig,
   createFile,
-  installPackages,
   readConfigFile,
   replaceFile,
   updateConfigFile,
 } from "../../../../utils.js";
-import { consola } from "consola";
 import { luciaGenerators } from "./generators.js";
 import {
   generateDrizzleAdapterDriverMappings,
@@ -30,13 +28,13 @@ export const addLucia = async () => {
   const {
     orm,
     provider,
-    preferredPackageManager,
     // packages,
     rootPath,
     driver,
     componentLib,
     t3,
   } = readConfigFile();
+
   // ask whether want to use shadcnui
   // consola.info(
   //   "Kirimase generates views and components for authenticating using Lucia."
@@ -73,55 +71,55 @@ export const addLucia = async () => {
   } else {
     viewsAndComponents = generateViewsAndComponents(false);
   }
-  createFile(
+  await createFile(
     formatFilePath(lucia.signInPage, {
       removeExtension: false,
       prefix: "rootPath",
     }),
     viewsAndComponents.signInPage
   );
-  createFile(
+  await createFile(
     formatFilePath(lucia.signUpPage, {
       removeExtension: false,
       prefix: "rootPath",
     }),
     viewsAndComponents.signUpPage
   );
-  createFile(
+  await createFile(
     formatFilePath(lucia.authFormComponent, {
       removeExtension: false,
       prefix: "rootPath",
     }),
     viewsAndComponents.authFormComponent
   );
-  replaceFile(
+  await replaceFile(
     formatFilePath(shared.init.dashboardRoute, {
       removeExtension: false,
       prefix: "rootPath",
     }),
     viewsAndComponents.homePage
   );
-  createFile(
+  await createFile(
     rootPath.concat("app/loading.tsx"),
     viewsAndComponents.loadingPage
   );
   // add API routes
   const apiRoutes = generateApiRoutes();
-  createFile(
+  await createFile(
     formatFilePath(lucia.signInApiRoute, {
       removeExtension: false,
       prefix: "rootPath",
     }),
     apiRoutes.signInRoute
   );
-  createFile(
+  await createFile(
     formatFilePath(lucia.signUpApiRoute, {
       removeExtension: false,
       prefix: "rootPath",
     }),
     apiRoutes.signUpRoute
   );
-  createFile(
+  await createFile(
     formatFilePath(lucia.signOutApiRoute, {
       removeExtension: false,
       prefix: "rootPath",
@@ -131,7 +129,7 @@ export const addLucia = async () => {
 
   // add app.d.ts
   const appDTs = generateAppDTs();
-  createFile(
+  await createFile(
     formatFilePath(lucia.appDTs, {
       removeExtension: false,
       prefix: "rootPath",
@@ -141,7 +139,7 @@ export const addLucia = async () => {
 
   const authDirFiles = generateAuthDirFiles(orm, driver, provider);
   // create auth/utils.ts
-  createFile(
+  await createFile(
     formatFilePath(shared.auth.authUtils, {
       removeExtension: false,
       prefix: "rootPath",
@@ -150,7 +148,7 @@ export const addLucia = async () => {
   );
 
   // create auth/lucia.ts
-  createFile(
+  await createFile(
     formatFilePath(lucia.libAuthLucia, {
       removeExtension: false,
       prefix: "rootPath",
@@ -167,7 +165,7 @@ export const addLucia = async () => {
         /\.references\(\(\) => user\.id\)/g,
         ""
       );
-      createFile(
+      await createFile(
         formatFilePath(shared.auth.authSchema, {
           removeExtension: false,
           prefix: "rootPath",
@@ -175,7 +173,7 @@ export const addLucia = async () => {
         schemaWithoutReferences
       );
     } else {
-      createFile(
+      await createFile(
         formatFilePath(shared.auth.authSchema, {
           removeExtension: false,
           prefix: "rootPath",
@@ -204,7 +202,7 @@ export const addLucia = async () => {
     const contentsWithPool = contentsImportsUpdated.concat(
       "\nexport const pool = new Pool({ connectionString: env.DATABASE_URL });"
     );
-    replaceFile(dbTsPath, contentsWithPool);
+    await replaceFile(dbTsPath, contentsWithPool);
   }
 
   // install packages (lucia, and adapter) will have to pull in specific package
@@ -217,12 +215,12 @@ export const addLucia = async () => {
 
   if (t3 && orm === "drizzle") {
     // replace server/db/index.ts to have connection exported
-    updateDrizzleDbIndex(provider);
+    await updateDrizzleDbIndex(provider);
     // updates to make sure shcmea is included in dbindex  too
   }
 
   // If trpc installed, add protectedProcedure
-  updateTrpcWithSessionIfInstalled();
+  await updateTrpcWithSessionIfInstalled();
 
   // await installPackages(
   //   { regular: `lucia ${adapterPackage}`, dev: "" },
@@ -231,7 +229,7 @@ export const addLucia = async () => {
   addToInstallList({ regular: ["lucia@2.7.7", adapterPackage], dev: [] });
 
   // add package to config
-  addPackageToConfig("lucia");
-  updateConfigFile({ auth: "lucia" });
+  await addPackageToConfig("lucia");
+  await updateConfigFile({ auth: "lucia" });
   // consola.success("Successfully installed Lucia!");
 };

--- a/src/commands/add/auth/lucia/utils.ts
+++ b/src/commands/add/auth/lucia/utils.ts
@@ -320,14 +320,14 @@ export const addLuciaToPrismaSchema = async () => {
     // write logic to check if model already exists -> if so replace
 
     const newContent = schemaContents.concat("\n", PrismaLuciaSchema);
-    replaceFile(schemaPath, newContent);
+    await replaceFile(schemaPath, newContent);
     // consola.success(`Added auth to Prisma schema`);
   } else {
     consola.info(`Prisma schema file does not exist`);
   }
 };
 
-export const updateDrizzleDbIndex = (provider: DBProvider) => {
+export const updateDrizzleDbIndex = async (provider: DBProvider) => {
   const { shared, drizzle } = getFilePaths();
   // what is it like to type like this'
   // functions intended use if with t3 so assumed provider is pscale
@@ -347,7 +347,7 @@ export const connection = connect({
  
 export const db = drizzle(connection, { schema });
 `;
-    replaceFile(
+    await replaceFile(
       formatFilePath(drizzle.dbIndex, {
         prefix: "rootPath",
         removeExtension: false,
@@ -356,5 +356,5 @@ export const db = drizzle(connection, { schema });
     );
   }
   // TODO: NOW
-  updateRootSchema("auth", true, "lucia");
+  await updateRootSchema("auth", true, "lucia");
 };

--- a/src/commands/add/auth/next-auth/generators.ts
+++ b/src/commands/add/auth/next-auth/generators.ts
@@ -453,7 +453,7 @@ export default function SignIn() {
           Signed in as{" "}
           <span className="font-medium">{session.user?.email}</span>
         </p>
-        <Button variant={"destructive"} onClick={() => signOut()}>
+        <Button variant={"destructive"} onClick={() => signOut({ callbackUrl: "/" })}>
           Sign out
         </Button>
       </div>
@@ -485,7 +485,7 @@ export default function SignIn() {
           <span className="font-medium">{session.user?.email}</span>
         </p>
         <button
-          onClick={() => signOut()}
+          onClick={() => signOut({ callbackUrl: "/" })}
           className="py-2.5 px-3.5 rounded-md bg-red-500 text-white hover:opacity-80 text-sm"
         >
           Sign out
@@ -665,5 +665,32 @@ export default async function Home() {
     </main>
   );
 }
+`;
+};
+
+export const generateSignInPage = () => {
+  return `"use client";
+
+import { signIn } from "next-auth/react";
+
+const Page = () => {
+  return (
+    <main className="bg-popover max-w-lg mx-auto my-4 rounded-lg p-10">
+      <h1 className="text-2xl font-bold text-center">
+        Sign in to your account
+      </h1>
+      <div className="mt-4">
+        <button
+          onClick={() => signIn(undefined, { callbackUrl: "/dashboard" })}
+          className="w-full bg-primary text-primary-foreground text-center hover:opacity-90 font-medium px-4 py-2 rounded-lg block"
+        >
+          Sign In
+        </button>
+      </div>
+    </main>
+  );
+};
+
+export default Page;
 `;
 };

--- a/src/commands/add/auth/next-auth/generators.ts
+++ b/src/commands/add/auth/next-auth/generators.ts
@@ -13,6 +13,7 @@ import {
   getDbIndexPath,
   getFilePaths,
 } from "../../../filePaths/index.js";
+import { formatFileContentWithPrettier } from "../../../init/utils.js";
 
 // 1. Create app/api/auth/[...nextauth].ts
 export const apiAuthNextAuthTsOld = (
@@ -510,7 +511,7 @@ export default function SignIn() {
 };
 
 // 6. updateTrpcTs
-export const updateTrpcTs = () => {
+export const updateTrpcTs = async () => {
   const { trpc } = getFilePaths();
   const filePath = formatFilePath(trpc.serverTrpc, {
     removeExtension: false,
@@ -545,14 +546,17 @@ export const protectedProcedure = t.procedure.use(enforceUserIsAuthed);
 `;
   const modifiedRouterContent = fileContent.concat(protectedProcedureContent);
 
-  fs.writeFileSync(filePath, modifiedRouterContent);
+  fs.writeFileSync(
+    filePath,
+    await formatFileContentWithPrettier(modifiedRouterContent,filePath)
+  );
 
   // consola.success(
   //   "TRPC Router updated successfully to add protectedProcedure."
   // );
 };
 
-export const enableSessionInContext = () => {
+export const enableSessionInContext = async () => {
   const { trpc } = getFilePaths();
   const filePath = formatFilePath(trpc.trpcContext, {
     prefix: "rootPath",
@@ -562,13 +566,16 @@ export const enableSessionInContext = () => {
   const fileContent = fs.readFileSync(filePath, "utf-8");
   const updatedContent = fileContent.replace(/\/\//g, "");
 
-  fs.writeFileSync(filePath, updatedContent);
+  fs.writeFileSync(
+    filePath,
+    await formatFileContentWithPrettier(updatedContent,filePath)
+  );
 
   // consola.success("TRPC Context updated successfully to add Session data.");
 };
 
 // no longer necessary
-export const enableSessionInTRPCApi_DEPRECATED = () => {
+export const enableSessionInTRPCApi_DEPRECATED = async () => {
   const { trpc } = getFilePaths();
   const filePath = formatFilePath(trpc.trpcApiTs, {
     prefix: "rootPath",
@@ -578,7 +585,10 @@ export const enableSessionInTRPCApi_DEPRECATED = () => {
   const fileContent = fs.readFileSync(filePath, "utf-8");
   const updatedContent = fileContent.replace(/\/\//g, "");
 
-  fs.writeFileSync(filePath, updatedContent);
+  fs.writeFileSync(
+    filePath,
+    await formatFileContentWithPrettier(updatedContent,filePath)
+  );
 
   // consola.success("TRPC Server API updated successfully to add Session data.");
 };

--- a/src/commands/add/auth/next-auth/index.ts
+++ b/src/commands/add/auth/next-auth/index.ts
@@ -1,8 +1,6 @@
-import { consola } from "consola";
 import {
   addPackageToConfig,
   createFile,
-  installPackages,
   readConfigFile,
   replaceFile,
   updateConfigFile,
@@ -17,7 +15,7 @@ import {
   libAuthProviderTsx,
   libAuthUtilsTs,
 } from "./generators.js";
-import { AuthDriver, AuthProvider, AuthProviders } from "./utils.js";
+import { AuthDriver, AuthProvider } from "./utils.js";
 import {
   addContextProviderToAppLayout,
   // addContextProviderToAuthLayout,
@@ -39,17 +37,15 @@ export const addNextAuth = async (
     hasSrc,
     preferredPackageManager,
     driver,
-    packages,
     orm,
     componentLib,
     provider: dbProvider,
     t3,
   } = readConfigFile();
-  const rootPath = `${hasSrc ? "src/" : ""}`;
   const { "next-auth": nextAuth, shared } = getFilePaths();
 
   // 1. Create app/api/auth/[...nextauth].ts
-  createFile(
+  await createFile(
     formatFilePath(nextAuth.nextAuthApiRoute, {
       removeExtension: false,
       prefix: "rootPath",
@@ -58,7 +54,7 @@ export const addNextAuth = async (
   );
 
   // 2. create lib/auth/Provider.tsx
-  createFile(
+  await createFile(
     formatFilePath(nextAuth.authProviderComponent, {
       removeExtension: false,
       prefix: "rootPath",
@@ -67,7 +63,7 @@ export const addNextAuth = async (
   );
 
   // 3. create lib/auth/utils.ts
-  createFile(
+  await createFile(
     formatFilePath(shared.auth.authUtils, {
       removeExtension: false,
       prefix: "rootPath",
@@ -78,7 +74,7 @@ export const addNextAuth = async (
   // 4. create lib/db/schema/auth.ts
   if (orm !== null) {
     if (orm === "drizzle") {
-      createFile(
+      await createFile(
         formatFilePath(shared.auth.authSchema, {
           removeExtension: false,
           prefix: "rootPath",
@@ -86,11 +82,11 @@ export const addNextAuth = async (
         createDrizzleAuthSchema(driver)
       );
       if (t3) {
-        updateRootSchema("auth", true, "next-auth");
+        await updateRootSchema("auth", true, "next-auth");
       }
     }
     if (orm === "prisma") {
-      addToPrismaSchema(
+      await addToPrismaSchema(
         createPrismaAuthSchema(
           driver,
           dbProvider === "planetscale",
@@ -102,7 +98,7 @@ export const addNextAuth = async (
   }
 
   // 5. create components/auth/SignIn.tsx - TODO - may be causing problems
-  createFile(
+  await createFile(
     formatFilePath(shared.auth.signInComponent, {
       removeExtension: false,
       prefix: "rootPath",
@@ -111,9 +107,9 @@ export const addNextAuth = async (
   );
 
   // 6. If trpc installed, add protectedProcedure // this wont run because it is installed before trpc
-  updateTrpcWithSessionIfInstalled();
+  await updateTrpcWithSessionIfInstalled();
 
-  replaceFile(
+  await replaceFile(
     formatFilePath(shared.init.dashboardRoute, {
       removeExtension: false,
       prefix: "rootPath",
@@ -122,7 +118,7 @@ export const addNextAuth = async (
   );
 
   // generate sign in page
-  createFile(
+  await createFile(
     formatFilePath(nextAuth.signInPage, {
       removeExtension: false,
       prefix: "rootPath",
@@ -131,7 +127,7 @@ export const addNextAuth = async (
   );
 
   // add to env
-  addToDotEnv(
+  await addToDotEnv(
     [
       {
         key: "NEXTAUTH_SECRET",
@@ -182,11 +178,11 @@ export const addNextAuth = async (
   if (orm !== null)
     addToInstallList({ regular: [AuthDriver[orm].package], dev: [] });
 
-  addPackageToConfig("next-auth");
-  updateConfigFile({ auth: "next-auth" });
+  await addPackageToConfig("next-auth");
+  await updateConfigFile({ auth: "next-auth" });
   // 9. Instruct user to add the <Provider /> to their root layout.
-  // addContextProviderToAuthLayout("NextAuthProvider");
-  addContextProviderToAppLayout("NextAuthProvider");
+  // await addContextProviderToAuthLayout("NextAuthProvider");
+  await addContextProviderToAppLayout("NextAuthProvider");
   if (orm === "prisma") await prismaGenerate(preferredPackageManager);
   // consola.success("Successfully added Next Auth to your project!");
 };

--- a/src/commands/add/auth/next-auth/index.ts
+++ b/src/commands/add/auth/next-auth/index.ts
@@ -12,6 +12,7 @@ import {
   createDrizzleAuthSchema,
   createPrismaAuthSchema,
   createSignInComponent,
+  generateSignInPage,
   generateUpdatedRootRoute,
   libAuthProviderTsx,
   libAuthUtilsTs,
@@ -118,6 +119,15 @@ export const addNextAuth = async (
       prefix: "rootPath",
     }),
     generateUpdatedRootRoute()
+  );
+
+  // generate sign in page
+  createFile(
+    formatFilePath(nextAuth.signInPage, {
+      removeExtension: false,
+      prefix: "rootPath",
+    }),
+    generateSignInPage()
   );
 
   // add to env

--- a/src/commands/add/auth/next-auth/utils.ts
+++ b/src/commands/add/auth/next-auth/utils.ts
@@ -58,7 +58,7 @@ export const AuthDriver: {
   },
 };
 
-export const checkAndAddAuthUtils = () => {
+export const checkAndAddAuthUtils = async () => {
   const { shared } = getFilePaths();
   const authUtilsPath = formatFilePath(shared.auth.authUtils, {
     removeExtension: false,
@@ -93,5 +93,5 @@ export const checkAuth = async () => {
   if (!session) redirect("/api/auth/signin");
 };
 `;
-  createFile(authUtilsPath, t3AuthUtilsContent);
+  await createFile(authUtilsPath, t3AuthUtilsContent);
 };

--- a/src/commands/add/auth/shared/generators.ts
+++ b/src/commands/add/auth/shared/generators.ts
@@ -468,6 +468,7 @@ export const createNavbar = (
   usingClerk = false,
   auth: AuthType
 ) => {
+  // TODO: Add supabase as auth provider
   const { shared, "next-auth": nextAuth } = getFilePaths();
   const { alias } = readConfigFile();
   let logOutRoute: string;

--- a/src/commands/add/auth/shared/index.ts
+++ b/src/commands/add/auth/shared/index.ts
@@ -1,9 +1,4 @@
-import { consola } from "consola";
-import {
-  createFile,
-  installShadcnUIComponents,
-  readConfigFile,
-} from "../../../../utils.js";
+import { createFile, readConfigFile } from "../../../../utils.js";
 import { addToShadcnComponentList } from "../../utils.js";
 import {
   createAccountApiTs,
@@ -12,7 +7,7 @@ import {
   createUserSettingsComponent,
   createUpdateNameCard,
   createUpdateEmailCard,
-  createNavbar,
+  // createNavbar,
   createSignOutBtn,
 } from "./generators.js";
 import { AuthType, ORMType } from "../../../../types.js";
@@ -26,9 +21,10 @@ export const createAccountSettingsPage = async () => {
   const { orm, rootPath, componentLib, auth } = readConfigFile();
   const { shared } = getFilePaths();
   const withShadCn = componentLib === "shadcn-ui" ? true : false;
+
   // create account api - clerk has managed component so no need
-  if (auth !== "clerk") {
-    createFile(
+  if (auth !== "supabase" && auth !== "clerk") {
+    await createFile(
       formatFilePath(shared.auth.accountApiRoute, {
         prefix: "rootPath",
         removeExtension: false,
@@ -38,7 +34,7 @@ export const createAccountSettingsPage = async () => {
   }
 
   // create account page
-  createFile(
+  await createFile(
     formatFilePath(shared.auth.accountPage, {
       prefix: "rootPath",
       removeExtension: false,
@@ -47,7 +43,7 @@ export const createAccountSettingsPage = async () => {
   );
 
   // create usersettings component
-  createFile(
+  await createFile(
     formatFilePath(shared.auth.userSettingsComponent, {
       prefix: "rootPath",
       removeExtension: false,
@@ -64,8 +60,9 @@ export const scaffoldAccountSettingsUI = async (
   auth: AuthType
 ) => {
   const { shared, lucia } = getFilePaths();
+
   // create updatenamecard
-  createFile(
+  await createFile(
     formatFilePath(shared.auth.updateNameCardComponent, {
       prefix: "rootPath",
       removeExtension: false,
@@ -74,7 +71,7 @@ export const scaffoldAccountSettingsUI = async (
   );
 
   // create updatenamecard
-  createFile(
+  await createFile(
     formatFilePath(shared.auth.updateEmailCardComponent, {
       prefix: "rootPath",
       removeExtension: false,
@@ -83,7 +80,7 @@ export const scaffoldAccountSettingsUI = async (
   );
 
   // create accountcard components
-  createFile(
+  await createFile(
     formatFilePath(shared.auth.accountCardComponent, {
       prefix: "rootPath",
       removeExtension: false,
@@ -92,7 +89,7 @@ export const scaffoldAccountSettingsUI = async (
   );
 
   // create navbar component
-  // createFile(
+  // await createFile(
   //   formatFilePath(shared.init.navbarComponent, {
   //     prefix: "rootPath",
   //     removeExtension: false,
@@ -100,8 +97,8 @@ export const scaffoldAccountSettingsUI = async (
   //   createNavbar(withShadCn, auth === "clerk", auth)
   // );
 
-  if (withShadCn) {
-    createFile(
+  if (withShadCn && auth !== "supabase") {
+    await createFile(
       formatFilePath(lucia.signOutButtonComponent, {
         prefix: "rootPath",
         removeExtension: false,
@@ -118,12 +115,12 @@ export const scaffoldAccountSettingsUI = async (
   }
 };
 
-export const updateTrpcWithSessionIfInstalled = () => {
+export const updateTrpcWithSessionIfInstalled = async () => {
   const { packages, t3 } = readConfigFile();
   if (packages.includes("trpc")) {
     if (!t3) {
-      updateTrpcTs();
-      enableSessionInContext();
+      await updateTrpcTs();
+      await enableSessionInContext();
     }
   }
 };

--- a/src/commands/add/auth/shared/index.ts
+++ b/src/commands/add/auth/shared/index.ts
@@ -22,7 +22,7 @@ export const createAccountSettingsPage = async () => {
   const { shared } = getFilePaths();
   const withShadCn = componentLib === "shadcn-ui" ? true : false;
 
-  // create account api - clerk has managed component so no need
+  // create account api - clerk has managed components so no need - supabase has its own client to update user details
   if (auth !== "supabase" && auth !== "clerk") {
     await createFile(
       formatFilePath(shared.auth.accountApiRoute, {

--- a/src/commands/add/auth/supabase/generators.ts
+++ b/src/commands/add/auth/supabase/generators.ts
@@ -1,0 +1,717 @@
+import { ORMType } from "../../../../types.js";
+import { readConfigFile } from "../../../../utils.js";
+import { formatFilePath, getFilePaths } from "../../../filePaths/index.js";
+
+const generateViewsAndComponents = (withShadCn: boolean) => {
+  const signUpPage = generateSignUpPage(withShadCn);
+  const signInPage = generateSignInPage(withShadCn);
+  const authFormComponent = generateAuthFormComponent(withShadCn);
+  const signOutButtonComponent = generateSignOutButtonComponent(withShadCn);
+  const homePage = generateHomePage();
+  const loadingPage = generateLoadingPage();
+
+  return {
+    signUpPage,
+    signInPage,
+    signOutButtonComponent,
+    authFormComponent,
+    homePage,
+    loadingPage,
+  };
+};
+
+export const generateSupabaseHelpers = () => {
+  const { shared } = getFilePaths();
+  return `
+    import { createBrowserClient, createServerClient, type CookieOptions } from '@supabase/ssr'
+    import { env } from "${formatFilePath(shared.init.envMjs, {
+      removeExtension: false,
+      prefix: "alias",
+    })}";
+    import { cookies } from 'next/headers'
+    import { type NextRequest, NextResponse } from "next/server";
+
+    export const supabaseBrowserClient = createBrowserClient(env.NEXT_PUBLIC_SUPABASE_URL, env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
+
+    export const createSupabaseServerClient = () => 
+        createServerClient(
+            env.NEXT_PUBLIC_SUPABASE_URL,
+            env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+            {
+                cookies: {
+                    get(name: string) {
+                        return cookies().get(name)?.value;
+                    },
+                    set(name: string, value: string, options: CookieOptions) {
+                        cookies().set({ name, value, ...options });
+                    },
+                    remove(name: string, options: CookieOptions) {
+                        cookies().set({ name, value: "", ...options });
+                    },
+                },
+            },
+        );
+
+    export const createSupabaseMiddlewareClient = (request: NextRequest) => {
+        // Create an unmodified response
+        let response = NextResponse.next({
+            request: {
+            headers: request.headers,
+            },
+        });
+
+        const supabase = createServerClient(
+            env.NEXT_PUBLIC_SUPABASE_URL,
+            env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+            {
+                cookies: {
+                    get(name: string) {
+                        return request.cookies.get(name)?.value;
+                    },
+                    set(name: string, value: string, options: CookieOptions) {
+                        // If the cookie is updated, update the cookies for the request and response
+                        request.cookies.set({
+                            name,
+                            value,
+                            ...options,
+                        });
+                        response = NextResponse.next({
+                            request: {
+                            headers: request.headers,
+                            },
+                        });
+                        response.cookies.set({
+                            name,
+                            value,
+                            ...options,
+                        });
+                    },
+                    remove(name: string, options: CookieOptions) {
+                        // If the cookie is removed, update the cookies for the request and response
+                        request.cookies.set({
+                            name,
+                            value: "",
+                            ...options,
+                        });
+                        response = NextResponse.next({
+                            request: {
+                            headers: request.headers,
+                            },
+                        });
+                        response.cookies.set({
+                            name,
+                            value: "",
+                            ...options,
+                        });
+                    },
+                },
+            }
+        );
+
+        return { supabase, response };
+    };
+
+    export const updateSession = async (request: NextRequest) => {
+        try {
+            const { supabase, response } = createSupabaseMiddlewareClient(request);
+            // This will refresh session if expired - required for Server Components
+            // https://supabase.com/docs/guides/auth/server-side/nextjs
+            await supabase.auth.getUser();
+
+            return response;
+        } catch (e) {
+            // If you are here, a Supabase client could not be created!
+            // This is likely because you have not set up environment variables.
+            // Check out http://localhost:3000 for Next Steps.
+            return NextResponse.next({
+                request: {
+                    headers: request.headers,
+                },
+            });
+        }
+    };
+`;
+};
+
+export const generateSignInPage = (withShadCn: boolean) => {
+  const { supabase, shared } = getFilePaths();
+  const { alias } = readConfigFile();
+  if (withShadCn) {
+    return `
+        import AuthForm from "${formatFilePath(supabase.authFormComponent, {
+          removeExtension: true,
+          prefix: "alias",
+        })}";
+        import { signIn } from "${formatFilePath(shared.auth.authUtils, {
+          prefix: "alias",
+          removeExtension: true,
+        })}";
+        import { Input } from "${alias}/components/ui/input";
+        import { Label } from "${alias}/components/ui/label";
+        import Link from "next/link";
+
+        const Page = async () => {
+            return (
+                <main className="max-w-lg mx-auto my-4 bg-popover p-10">
+                    <h1 className="text-2xl font-bold text-center">
+                        Sign in to your account
+                    </h1>
+                    <AuthForm action={signIn} authType="sign-up">
+                        <Label htmlFor="username" className="text-muted-foreground">
+                            Username
+                        </Label>
+                        <Input name="username" id="username" />
+                        <br />
+                        <Label htmlFor="password" className="text-muted-foreground">
+                            Password
+                        </Label>
+                        <Input type="password" name="password" id="password" />
+                        <br />
+                    </AuthForm>
+                    <div className="mt-4 text-sm text-center text-muted-foreground">
+                        Don&apos;t have an account yet?{" "}
+                        <Link
+                            href="/sign-up"
+                            className="text-accent-foreground underline hover:text-primary"
+                        >
+                            Create an account
+                        </Link>
+                    </div>
+                </main>
+            );
+        };
+        export default Page;
+    `;
+  } else {
+    return `
+      import AuthForm from "${formatFilePath(supabase.authFormComponent, {
+        removeExtension: true,
+        prefix: "alias",
+      })}";
+        import { signUp } from "${formatFilePath(shared.auth.authUtils, {
+          prefix: "alias",
+          removeExtension: true,
+        })}";
+        import Link from "next/link";
+
+        const Page = async () => {
+            return (
+                <main className="max-w-lg mx-auto my-4 bg-white p-10">
+                    <h1 className="text-2xl font-bold text-center">
+                        Sign in to your account
+                    </h1>
+                    <AuthForm action={signUp} authType="sign-up">
+                        <label
+                            htmlFor="username"
+                            className="block font-medium text-sm text-neutral-500"
+                        >
+                            Username
+                        </label>
+                        <input
+                            name="username"
+                            id="username"
+                            className="block w-full px-3 py-2 rounded-md border border-neutral-200 focus:outline-neutral-700"
+                        />
+                        <br />
+                        <label
+                            htmlFor="password"
+                            className="block font-medium text-sm text-neutral-500"
+                        >
+                            Password
+                        </label>
+                        <input
+                            type="password"
+                            name="password"
+                            id="password"
+                            className="block w-full px-3 py-2 rounded-md border border-neutral-200 focus:outline-neutral-700"
+                        />
+                        <br />
+                    </AuthForm>
+                    <div className="mt-4 text-sm text-center text-muted-foreground">
+                        Don&apos;t have an account yet?{" "}
+                        <Link
+                            href="/sign-up"
+                            className="text-accent-foreground underline hover:text-primary"
+                        >
+                            Create an account
+                        </Link>
+                    </div>
+                </main>
+            );
+        };
+        export default Page;
+    `;
+  }
+};
+
+export const generateSignUpPage = (withShadCn: boolean) => {
+  const { supabase, shared } = getFilePaths();
+  const { alias } = readConfigFile();
+  if (withShadCn) {
+    return `
+        import AuthForm from "${formatFilePath(supabase.authFormComponent, {
+          removeExtension: true,
+          prefix: "alias",
+        })}";
+        import { signUp } from "${formatFilePath(shared.auth.authUtils, {
+          prefix: "alias",
+          removeExtension: true,
+        })}";
+        import { Input } from "${alias}/components/ui/input";
+        import { Label } from "${alias}/components/ui/label";
+        import Link from "next/link";
+
+        const Page = async () => {
+            return (
+                <main className="max-w-lg mx-auto my-4 bg-popover p-10">
+                    <h1 className="text-2xl font-bold text-center">Create an account</h1>
+                    <AuthForm action={signUp} authType="sign-up">
+                        <Label htmlFor="username" className="text-muted-foreground">
+                            Username
+                        </Label>
+                        <Input name="username" id="username" />
+                        <br />
+                        <Label htmlFor="password" className="text-muted-foreground">
+                            Password
+                        </Label>
+                        <Input type="password" name="password" id="password" />
+                        <br />
+                    </AuthForm>
+                    <div className="mt-4 text-muted-foreground text-center text-sm">
+                        Already have an account?{" "}
+                        <Link href="/sign-in" className="text-secondary-foreground underline">
+                            Sign in
+                        </Link>
+                    </div>
+                </main>
+            );
+        };
+        export default Page;
+    `;
+  } else {
+    return `
+      import AuthForm from "${formatFilePath(supabase.authFormComponent, {
+        removeExtension: true,
+        prefix: "alias",
+      })}";
+        import { signUp } from "${formatFilePath(shared.auth.authUtils, {
+          prefix: "alias",
+          removeExtension: true,
+        })}";
+        import Link from "next/link";
+
+        const Page = async () => {
+            return (
+                <main className="max-w-lg mx-auto my-4 bg-white p-10">
+                    <h1 className="text-2xl font-bold text-center">Create an account</h1>
+                    <AuthForm action={signUp} authType="sign-up">
+                        <label
+                            htmlFor="username"
+                            className="block font-medium text-sm text-neutral-500"
+                        >
+                            Username
+                        </label>
+                        <input
+                            name="username"
+                            id="username"
+                            className="block w-full px-3 py-2 rounded-md border border-neutral-200 focus:outline-neutral-700"
+                        />
+                        <br />
+                        <label
+                            htmlFor="password"
+                            className="block font-medium text-sm text-neutral-500"
+                        >
+                            Password
+                        </label>
+                        <input
+                            type="password"
+                            name="password"
+                            id="password"
+                            className="block w-full px-3 py-2 rounded-md border border-neutral-200 focus:outline-neutral-700"
+                        />
+                        <br />
+                    </AuthForm>
+                    <div className="mt-4 text-neutral-500 text-center text-sm">
+                        Already have an account?{" "}
+                        <Link href="/sign-in" className="text-black underline hover:opacity-70">
+                            Sign in
+                        </Link>
+                    </div>
+                </main>
+            );
+        };
+        export default Page;
+    `;
+  }
+};
+
+export const generateSignOutButtonComponent = (withShadCn: boolean) => {
+  const { alias } = readConfigFile();
+  const { shared } = getFilePaths();
+  if (withShadCn) {
+    return `"use client";
+import { Button } from "${alias}/components/ui/button";
+import { signOut } from "${formatFilePath(shared.auth.authUtils, {
+      prefix: "alias",
+      removeExtension: true,
+    })}";
+
+export const SignOutButton = () => {
+  return (
+    <Button onClick={signOut} className='bg-red-600 text-foreground'>
+       Sign Out
+    </Button>
+   );
+};
+    `;
+  } else {
+    return `
+"use client";
+
+import { signOut } from "${formatFilePath(shared.auth.authUtils, {
+      prefix: "alias",
+      removeExtension: true,
+    })}";
+
+export const SignOutButton = () => {
+    return (
+        <button onClick={signOut} className='bg-red-600 text-foreground'>
+            Sign Out
+        </button>
+    );
+};
+`;
+  }
+};
+
+export const generateAuthFormComponent = (withShadCn: boolean) => {
+  const { alias } = readConfigFile();
+  const { shared } = getFilePaths();
+  const authForm = `
+        "use client";
+
+        import { useFormState, useFormStatus } from "react-dom";
+        import { redirect } from 'next/navigation';
+        import { Button } from "${alias}/components/ui/button";
+        import { type State } from "${formatFilePath(shared.auth.authUtils, {
+          prefix: "alias",
+          removeExtension: true,
+        })}";
+        
+        type AuthType = 'sign-in' | 'sign-up'
+        type ServerAction = (state: State, formData: FormData) => State | Promise<State>
+
+        function AuthForm({
+            action,
+            authType,
+            children
+        }: {
+            action: ServerAction
+            authType: AuthType
+            children?: React.ReactNode
+        }) {
+            const [state, formAction] = useFormState(action, null)
+
+            if (state?.redirectTo) redirect(state.redirectTo)
+
+            return (
+                <div className='flex-1 flex flex-col w-full px-8 sm:max-w-md justify-center gap-2'>
+                    <form
+                        className='animate-in flex-1 flex flex-col w-full justify-center gap-2 text-foreground'
+                        action={formAction}>
+                        {children}
+
+                        {state?.error && <span className='text-red-600'>{state.error.message}</span>}
+
+                        {state?.message && <span className='text-green-600'>{state.message}</span>}
+
+                        <SubmitButton authType={authType} />
+                    </form>
+                </div>
+            )
+        }
+
+        export default AuthForm
+
+        const SubmitButton = ({ authType }: { authType: AuthType }) => {
+        const buttonSuffix = authType === 'sign-in' ? 'in' : 'up'
+
+        const { pending } = useFormStatus()
+        `;
+
+  if (withShadCn) {
+    return (
+      authForm +
+      `
+                    return (
+                        <Button
+                        type='submit' 
+                        className='w-full' 
+                        disabled={pending}
+                        variant='default'>
+                            Sign{pending ? 'ing' : ''} {buttonSuffix}
+                        </Button>
+                    )}`
+    );
+  } else {
+    return (
+      authForm +
+      `
+                    return (
+                        <button
+                        type='submit' 
+                        className='w-full' 
+                        disabled={pending}
+                        >
+                            Sign{pending ? 'ing' : ''} {buttonSuffix}
+                        </button>
+                    )}`
+    );
+  }
+};
+
+export const generateHomePage = () => {
+  const { supabase, shared } = getFilePaths();
+  const { componentLib } = readConfigFile();
+  return `
+    import { SignOutButton } from "${formatFilePath(
+      supabase.signOutButtonComponent,
+      {
+        removeExtension: true,
+        prefix: "alias",
+      }
+    )}";
+    import { getUserAuth } from "${formatFilePath(shared.auth.authUtils, {
+      prefix: "alias",
+      removeExtension: true,
+    })}";
+
+    export default async function Home() {
+    const { session } = await getUserAuth();
+    return (
+        <main className="">
+            <h1 className="text-2xl font-bold my-2">Profile</h1>
+            <pre className="${
+              componentLib === "shadcn-ui"
+                ? "bg-secondary"
+                : "bg-neutral-100 dark:bg-neutral-800"
+            } p-4 rounded-lg my-2">
+                {JSON.stringify(session, null, 2)}
+            </pre>
+            <SignOutButton />
+        </main>
+    );
+    }
+`;
+};
+export const generateLoadingPage = () => {
+  const { componentLib } = readConfigFile();
+  const withShadCn = componentLib === "shadcn-ui";
+  return `
+    export default function Loading() {
+    return (
+        <div className="grid place-items-center animate-pulse ${
+          withShadCn ? "text-muted-foreground" : "text-neutral-300"
+        } p-4">
+        <div role="status">
+            <svg
+            aria-hidden="true"
+            className="w-8 h-8 ${
+              withShadCn
+                ? "text-muted-foreground fill-muted"
+                : "text-neutral-200 dark:text-neutral-600 fill-neutral-600"
+            } animate-spin"
+            viewBox="0 0 100 101"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            >
+            <path
+                d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+                fill="currentColor"
+            />
+            <path
+                d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+                fill="currentFill"
+            />
+            </svg>
+            <span className="sr-only">Loading...</span>
+        </div>
+        </div>
+    );
+    }
+    `;
+};
+
+export const generateApiRoutes = () => {
+  const { supabase } = getFilePaths();
+  return `
+        import { createSupabaseServerClient } from "${formatFilePath(
+          supabase.libAuthSupabase,
+          {
+            removeExtension: true,
+            prefix: "alias",
+          }
+        )}";
+        import { NextRequest, NextResponse } from "next/server";
+
+        export async function GET(request: NextRequest) {
+            const requestUrl = new URL(request.url);
+            const code = requestUrl.searchParams.get("code");
+
+            if (code) {
+                const supabase = createSupabaseServerClient();
+                await supabase.auth.exchangeCodeForSession(code);
+            }
+
+            // URL to redirect to after sign in process completes
+            return NextResponse.redirect(requestUrl.origin);
+        }
+    `;
+};
+
+const generateAuthDirFiles = (orm: ORMType) => {
+  const { supabase } = getFilePaths();
+  const utilsTs = `
+    import { redirect } from "next/navigation";
+    import { createSupabaseServerClient } from "${formatFilePath(
+      supabase.libAuthSupabase,
+      {
+        removeExtension: true,
+        prefix: "alias",
+      }
+    )}";
+
+    export const getServerSession = async () => {
+        const supabase = createSupabaseServerClient();
+        const {
+            data: { session }
+        } = await supabase.auth.getSession()
+
+        return { session };
+    };
+
+    export const getServerUser = async () => {
+        const supabase = createSupabaseServerClient()
+        const {
+            data: { user }
+        } = await supabase.auth.getUser()
+
+        return { user }
+    }
+
+    export type AuthSession = {
+        session: {
+            user: {
+                id: string;
+                name?: string;
+                email?: string;
+            };
+        } | null;
+    };
+
+    export const getUserAuth = async () => {
+        const { user } = await getServerUser();
+
+        if (user) {
+            return {
+                session: {
+                    user: {
+                        id: user.id,
+                        name: "",
+                        email: user.email,
+                    },
+                },
+            } as AuthSession;
+        } else {
+            return { session: null };
+        }
+    };
+
+    export const checkAuth = async () => {
+        const { session } = await getUserAuth();
+
+        if (!session) redirect("/sign-in");
+    };
+
+    // ---------------------------------------------------
+    // You can move these functions to a separate file and/or directory if you want but make sure to update the import paths
+    import { type AuthError } from '@supabase/supabase-js'
+
+    export type State = {
+        error?: AuthError
+        message?: string
+        redirectTo?: string
+    } | null
+
+    export const signOut = async () => {
+        'use server'
+        const supabase = createSupabaseServerClient()
+        await supabase.auth.signOut()
+        redirect('/')
+    }
+
+    export const signIn = async (state: State, formData: FormData) => {
+        'use server'
+        const supabase = createSupabaseServerClient()
+        const email = formData.get('email') as string
+        const password = formData.get('password') as string
+
+        const { error } = await supabase.auth.signInWithPassword({ email, password })
+
+        if (error) return { error }
+
+        return { redirectTo: '/' }
+    }
+
+    export const signUp = async (state: State, formData: FormData) => {
+        'use server'
+        const supabase = createSupabaseServerClient()
+        const email = formData.get('email') as string
+        const password = formData.get('password') as string
+
+        const { error } = await supabase.auth.signUp({ email, password })
+
+        if (error) return { error }
+
+        return { redirectTo: '/' }
+    }
+`;
+
+  return { utilsTs };
+};
+
+const generateMiddleware = () => {
+  const { supabase } = getFilePaths();
+  return `
+    import { type NextRequest } from "next/server";
+    import { updateSession } from "${formatFilePath(supabase.libAuthSupabase, {
+      removeExtension: true,
+      prefix: "alias",
+    })}";
+
+    export async function middleware(request: NextRequest) {
+        return await updateSession(request);
+    }
+
+    export const config = {
+        matcher: [
+            /*
+            * Match all request paths except:
+            * - _next/static (static files)
+            * - _next/image (image optimization files)
+            * - favicon.ico (favicon file)
+            * - images - .svg, .png, .jpg, .jpeg, .gif, .webp
+            * Feel free to modify this pattern to include more paths.
+            */
+            "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+        ],
+    }; `;
+};
+
+export const supabaseGenerators = {
+  generateMiddleware,
+  generateViewsAndComponents,
+  generateSupabaseHelpers,
+  generateApiRoutes,
+  generateAuthDirFiles,
+};

--- a/src/commands/add/auth/supabase/index.ts
+++ b/src/commands/add/auth/supabase/index.ts
@@ -126,8 +126,9 @@ export const addSupabase = async () => {
     apiRoute
   );
 
-  const authDirFiles = generateAuthDirFiles(orm);
+  const authDirFiles = generateAuthDirFiles();
 
+  // create auth utility functions
   await createFile(
     formatFilePath(shared.auth.authUtils, {
       removeExtension: false,
@@ -136,10 +137,20 @@ export const addSupabase = async () => {
     authDirFiles.utilsTs
   );
 
+  // create auth actions
+  await createFile(
+    formatFilePath(shared.auth.authActions, {
+      removeExtension: false,
+      prefix: "rootPath",
+    }),
+    authDirFiles.actionTs
+  );
+
   const helpers = generateSupabaseHelpers();
 
+  // generate supabase helpers
   await createFile(
-    formatFilePath(supabase.libAuthSupabase, {
+    formatFilePath(supabase.libSupabaseAuthHelpers, {
       removeExtension: false,
       prefix: "rootPath",
     }),
@@ -147,8 +158,8 @@ export const addSupabase = async () => {
   );
 
   const supabasePackages = ["@supabase/supabase-js", "@supabase/ssr"];
-  const adapterPackage = orm === "drizzle" && ["postgres"];
-  const packagesToInstall = [...supabasePackages, ...adapterPackage];
+  // const adapterPackage = orm === "drizzle" && ["postgres"];
+  const packagesToInstall = [...supabasePackages];
 
   addToInstallList({ regular: packagesToInstall, dev: [] });
 

--- a/src/commands/add/auth/supabase/index.ts
+++ b/src/commands/add/auth/supabase/index.ts
@@ -158,8 +158,9 @@ export const addSupabase = async () => {
   );
 
   const supabasePackages = ["@supabase/supabase-js", "@supabase/ssr"];
-  // const adapterPackage = orm === "drizzle" && ["postgres"];
-  const packagesToInstall = [...supabasePackages];
+  const zodPackages = ["zod", "zod-form-data"];
+
+  const packagesToInstall = [...supabasePackages, ...zodPackages];
 
   addToInstallList({ regular: packagesToInstall, dev: [] });
 

--- a/src/commands/add/auth/supabase/index.ts
+++ b/src/commands/add/auth/supabase/index.ts
@@ -1,0 +1,158 @@
+/*
+ 1. Add Env keys in env.mjs too
+  2. Add middleware
+  3. Scaffold Signup and Signin pages
+  4. Create Signout button
+  5. Create AuthForm component
+  6. Create Home page
+  7. Create Loading page
+  8. Add API routes
+  9. Add Supabase helpers
+  10. Add Supabase packages
+  11. Add package to config
+  12. Update config file
+*/
+
+import {
+  addPackageToConfig,
+  createFile,
+  readConfigFile,
+  updateConfigFile,
+} from "../../../../utils.js";
+import { supabaseGenerators } from "./generators.js";
+import { formatFilePath, getFilePaths } from "../../../filePaths/index.js";
+import { addToInstallList } from "../../utils.js";
+import { addToDotEnv } from "../../orm/drizzle/generators.js";
+export const addSupabase = async () => {
+  const { orm, rootPath, componentLib } = readConfigFile();
+  const { supabase, shared } = getFilePaths();
+
+  const {
+    generateMiddleware,
+    generateViewsAndComponents,
+    generateSupabaseHelpers,
+    generateApiRoutes,
+    generateAuthDirFiles,
+  } = supabaseGenerators;
+
+  await addToDotEnv(
+    [
+      {
+        key: "NEXT_PUBLIC_SUPABASE_URL",
+        value: "your-project-url",
+        public: true,
+      },
+      {
+        key: "NEXT_PUBLIC_SUPABASE_ANON_KEY",
+        value: "your-anon-key",
+        public: true,
+      },
+    ],
+    rootPath
+  );
+
+  await createFile(
+    formatFilePath(supabase.middleware, {
+      prefix: "rootPath",
+      removeExtension: false,
+    }),
+    generateMiddleware()
+  );
+
+  const useShadCnUI = componentLib === "shadcn-ui";
+
+  // create auth form component
+  // generate sign-in and sign-up pages
+  const viewsAndComponents = generateViewsAndComponents(useShadCnUI);
+
+  // create signIn Page
+  await createFile(
+    formatFilePath(supabase.signInPage, {
+      prefix: "rootPath",
+      removeExtension: false,
+    }),
+    viewsAndComponents.signInPage
+  );
+
+  // create signUp Page
+  await createFile(
+    formatFilePath(supabase.signUpPage, {
+      prefix: "rootPath",
+      removeExtension: false,
+    }),
+    viewsAndComponents.signUpPage
+  );
+
+  // create signOut Button
+  await createFile(
+    formatFilePath(supabase.signOutButtonComponent, {
+      prefix: "rootPath",
+      removeExtension: false,
+    }),
+    viewsAndComponents.signOutButtonComponent
+  );
+
+  // create auth form component
+  await createFile(
+    formatFilePath(supabase.authFormComponent, {
+      prefix: "rootPath",
+      removeExtension: false,
+    }),
+    viewsAndComponents.authFormComponent
+  );
+
+  // create home Page
+  await createFile(
+    formatFilePath(shared.init.dashboardRoute, {
+      prefix: "rootPath",
+      removeExtension: false,
+    }),
+    viewsAndComponents.homePage
+  );
+
+  await createFile(
+    rootPath.concat("app/loading.tsx"),
+    viewsAndComponents.loadingPage
+  );
+
+  // add API routes
+  const apiRoute = generateApiRoutes();
+
+  await createFile(
+    formatFilePath(supabase.callbackApiRoute, {
+      removeExtension: false,
+      prefix: "rootPath",
+    }),
+    apiRoute
+  );
+
+  const authDirFiles = generateAuthDirFiles(orm);
+
+  await createFile(
+    formatFilePath(shared.auth.authUtils, {
+      removeExtension: false,
+      prefix: "rootPath",
+    }),
+    authDirFiles.utilsTs
+  );
+
+  const helpers = generateSupabaseHelpers();
+
+  await createFile(
+    formatFilePath(supabase.libAuthSupabase, {
+      removeExtension: false,
+      prefix: "rootPath",
+    }),
+    helpers
+  );
+
+  const supabasePackages = ["@supabase/supabase-js", "@supabase/ssr"];
+  const adapterPackage = orm === "drizzle" && ["postgres"];
+  const packagesToInstall = [...supabasePackages, ...adapterPackage];
+
+  addToInstallList({ regular: packagesToInstall, dev: [] });
+
+  // add package to config
+  await addPackageToConfig("supabase");
+  await updateConfigFile({ auth: "supabase" });
+};

--- a/src/commands/add/auth/supabase/utils.ts
+++ b/src/commands/add/auth/supabase/utils.ts
@@ -5,8 +5,8 @@ import fs from "fs";
 // TODO: Idk if this is necessary for Supabase
 export const addToSupabasegnoredRoutes = async (newPath: string) => {
   const { supabase } = getFilePaths();
-  const initMWContent = "ignoredRoutes: [";
-  const updatedMWContent = "ignoredRoutes: [" + ` "${newPath}", `;
+  const initMWContent = "matcher: [";
+  const updatedMWContent = "matcher: [" + ` "${newPath}", `;
   const mwPath = formatFilePath(supabase.middleware, {
     prefix: "rootPath",
     removeExtension: false,

--- a/src/commands/add/auth/supabase/utils.ts
+++ b/src/commands/add/auth/supabase/utils.ts
@@ -2,19 +2,26 @@ import { replaceFile } from "../../../../utils.js";
 import { formatFilePath, getFilePaths } from "../../../filePaths/index.js";
 import fs from "fs";
 
-// TODO: Idk if this is necessary for Supabase
-export const addToSupabasegnoredRoutes = async (newPath: string) => {
+// TODO: Find out if this is actually necessary for Supabase
+export const addToSupabaseIgnoredRoutes = async (newPath: string) => {
   const { supabase } = getFilePaths();
+
   const initMWContent = "matcher: [";
+
   const updatedMWContent = "matcher: [" + ` "${newPath}", `;
+
   const mwPath = formatFilePath(supabase.middleware, {
     prefix: "rootPath",
     removeExtension: false,
   });
+
   const mwExists = fs.existsSync(mwPath);
+
   if (mwExists) {
     const mwContent = fs.readFileSync(mwPath, "utf-8");
+
     const newUtilsContent = mwContent.replace(initMWContent, updatedMWContent);
+
     await replaceFile(mwPath, newUtilsContent);
   } else {
     console.error("Middleware does not exist");

--- a/src/commands/add/auth/supabase/utils.ts
+++ b/src/commands/add/auth/supabase/utils.ts
@@ -1,0 +1,22 @@
+import { replaceFile } from "../../../../utils.js";
+import { formatFilePath, getFilePaths } from "../../../filePaths/index.js";
+import fs from "fs";
+
+// TODO: Idk if this is necessary for Supabase
+export const addToSupabasegnoredRoutes = async (newPath: string) => {
+  const { supabase } = getFilePaths();
+  const initMWContent = "ignoredRoutes: [";
+  const updatedMWContent = "ignoredRoutes: [" + ` "${newPath}", `;
+  const mwPath = formatFilePath(supabase.middleware, {
+    prefix: "rootPath",
+    removeExtension: false,
+  });
+  const mwExists = fs.existsSync(mwPath);
+  if (mwExists) {
+    const mwContent = fs.readFileSync(mwPath, "utf-8");
+    const newUtilsContent = mwContent.replace(initMWContent, updatedMWContent);
+    await replaceFile(mwPath, newUtilsContent);
+  } else {
+    console.error("Middleware does not exist");
+  }
+};

--- a/src/commands/add/componentLib/shadcn-ui/index.ts
+++ b/src/commands/add/componentLib/shadcn-ui/index.ts
@@ -160,7 +160,7 @@ export default function SignIn() {
     return (
       <>
         Signed in as {session.user?.email} <br />
-        <Button variant={"destructive"} onClick={() => signOut()}>Sign out</Button>
+        <Button variant={"destructive"} onClick={() => signOut({ callbackUrl: "/" })}>Sign out</Button>
       </>
     );
   }

--- a/src/commands/add/componentLib/shadcn-ui/index.ts
+++ b/src/commands/add/componentLib/shadcn-ui/index.ts
@@ -58,9 +58,9 @@ const manualInstallShadCn = async (
   });
 
   // add tailwind.config.ts
-  createFile("tailwind.config.ts", generateTailwindConfig(rootPath));
+  await createFile("tailwind.config.ts", generateTailwindConfig(rootPath));
   // update globals.css
-  replaceFile(
+  await replaceFile(
     formatFilePath(shared.init.globalCss, {
       prefix: "rootPath",
       removeExtension: false,
@@ -68,25 +68,25 @@ const manualInstallShadCn = async (
     generateGlobalsCss()
   );
   // add cn helper (lib/utils.ts)
-  createFile(rootPath.concat("lib/utils.ts"), generateLibUtilsTs());
+  await createFile(rootPath.concat("lib/utils.ts"), generateLibUtilsTs());
   // create components.json
-  createFile("components.json", generateComponentsJson(rootPath));
+  await createFile("components.json", generateComponentsJson(rootPath));
 
-  createFile(rootPath.concat("app/loading.tsx"), generateLoadingPage());
+  await createFile(rootPath.concat("app/loading.tsx"), generateLoadingPage());
 
   // todo: install theme switcher
   // create theme provider
-  createFile(
+  await createFile(
     rootPath.concat("components/ThemeProvider.tsx"),
     generateThemeProvider()
   );
   //generate theme toggler
-  createFile(
+  await createFile(
     rootPath.concat("components/ui/ThemeToggle.tsx"),
     generateThemeToggler()
   );
   // add context provider to layout
-  addContextProviderToRootLayout("ThemeProvider");
+  await addContextProviderToRootLayout("ThemeProvider");
 };
 
 export const installShadcnUI = async (
@@ -107,8 +107,8 @@ export const installShadcnUI = async (
 
   if (existsSync(filePath)) {
     consola.info("Shadcn is already installed. Adding Shadcn UI to config...");
-    addPackageToConfig("shadcn-ui");
-    updateConfigFile({ componentLib: "shadcn-ui" });
+    await addPackageToConfig("shadcn-ui");
+    await updateConfigFile({ componentLib: "shadcn-ui" });
   } else {
     try {
       // await execa(pmInstallCommand[preferredPackageManager], installArgs, {
@@ -116,8 +116,8 @@ export const installShadcnUI = async (
       // });
       await manualInstallShadCn(preferredPackageManager, rootPath);
       // consola.success("Shadcn initialized successfully.");
-      addPackageToConfig("shadcn-ui");
-      updateConfigFile({ componentLib: "shadcn-ui" });
+      await addPackageToConfig("shadcn-ui");
+      await updateConfigFile({ componentLib: "shadcn-ui" });
     } catch (error) {
       consola.error(`Failed to initialize Shadcn: ${error.message}`);
     }
@@ -139,12 +139,12 @@ export const installShadcnUI = async (
     "dropdown-menu",
   ]);
 
-  addContextProviderToAppLayout("ShadcnToast");
+  await addContextProviderToAppLayout("ShadcnToast");
 
   // if (packages.includes("next-auth")) updateSignInComponentWithShadcnUI();
 };
 
-export const updateSignInComponentWithShadcnUI = () => {
+export const updateSignInComponentWithShadcnUI = async () => {
   const { hasSrc, alias } = readConfigFile();
   const filepath = "components/auth/SignIn.tsx";
   const updatedContent = `"use client";
@@ -171,5 +171,5 @@ export default function SignIn() {
     </>
   );
 }`;
-  replaceFile(`${hasSrc ? "src/" : ""}${filepath}`, updatedContent);
+  await replaceFile(`${hasSrc ? "src/" : ""}${filepath}`, updatedContent);
 };

--- a/src/commands/add/index.ts
+++ b/src/commands/add/index.ts
@@ -1,11 +1,5 @@
 import { confirm } from "@inquirer/prompts";
-import {
-  createFile,
-  installPackages,
-  readConfigFile,
-  replaceFile,
-  updateConfigFile,
-} from "../../utils.js";
+import { readConfigFile, replaceFile, updateConfigFile } from "../../utils.js";
 import { addDrizzle } from "./orm/drizzle/index.js";
 import { addNextAuth } from "./auth/next-auth/index.js";
 import { addTrpc } from "./misc/trpc/index.js";
@@ -15,6 +9,7 @@ import { initProject } from "../init/index.js";
 import { addPrisma } from "./orm/prisma/index.js";
 import { ORMType, InitOptions } from "../../types.js";
 import { addClerk } from "./auth/clerk/index.js";
+import { addSupabase } from "./auth/supabase/index.js";
 import { addResend } from "./misc/resend/index.js";
 import { addLucia } from "./auth/lucia/index.js";
 import { createAccountSettingsPage } from "./auth/shared/index.js";
@@ -136,8 +131,8 @@ export const addPackage = async (options?: InitOptions) => {
     spinner.start();
     spinner.text = "Beginning Configuration Process";
 
-    createAppLayoutFile();
-    createLandingPage();
+    await createAppLayoutFile();
+    await createLandingPage();
 
     if (config.componentLib === undefined) {
       if (promptResponse.componentLib === "shadcn-ui") {
@@ -154,20 +149,20 @@ export const addPackage = async (options?: InitOptions) => {
         //   config.preferredPackageManager
         // );
         // add to tailwindconfig
-        replaceFile("tailwind.config.ts", generateUpdatedTWConfig());
+        await replaceFile("tailwind.config.ts", generateUpdatedTWConfig());
 
         // add to globalcss colors
-        replaceFile(
+        await replaceFile(
           formatFilePath(shared.init.globalCss, {
             removeExtension: false,
             prefix: "rootPath",
           }),
           generateGlobalsCss()
         );
-        updateConfigFile({ componentLib: null });
+        await updateConfigFile({ componentLib: null });
       }
       if (!config.t3) {
-        addContextProviderToAppLayout("Navbar");
+        await addContextProviderToAppLayout("Navbar");
       }
     }
 
@@ -193,7 +188,7 @@ export const addPackage = async (options?: InitOptions) => {
         );
       }
       if (promptResponse === null)
-        updateConfigFile({ orm: null, driver: null, provider: null });
+        await updateConfigFile({ orm: null, driver: null, provider: null });
     }
     // check if auth
     if (config.auth === undefined) {
@@ -202,27 +197,28 @@ export const addPackage = async (options?: InitOptions) => {
           "Configuring " +
           promptResponse.auth[0].toUpperCase() +
           promptResponse.orm.slice(1);
-      if (promptResponse.auth) createAuthLayoutFile();
+      if (promptResponse.auth) await createAuthLayoutFile();
       if (promptResponse.auth === "next-auth")
         await addNextAuth(promptResponse.authProviders, options);
       if (promptResponse.auth === "clerk") await addClerk();
       if (promptResponse.auth === "lucia") await addLucia();
       if (promptResponse.auth === "kinde") await addKinde();
+      if (promptResponse.auth === "supabase") await addSupabase();
       if (!promptResponse.auth) {
-        replaceFile(
+        await replaceFile(
           formatFilePath(shared.init.dashboardRoute, {
             prefix: "rootPath",
             removeExtension: false,
           }),
           generateGenericHomepage()
         );
-        updateConfigFile({ auth: null });
+        await updateConfigFile({ auth: null });
       } else {
         // add account page
         await createAccountSettingsPage();
       }
-      addNavbarAndSettings();
-      addAuthCheckToAppLayout();
+      await addNavbarAndSettings();
+      await addAuthCheckToAppLayout();
     }
 
     // check if misc
@@ -243,7 +239,7 @@ export const addPackage = async (options?: InitOptions) => {
     }
 
     if (config.t3 && config.auth === "next-auth") {
-      checkAndAddAuthUtils();
+      await checkAndAddAuthUtils();
     }
     spinner.succeed("Configuration complete");
 

--- a/src/commands/add/misc/defaultStyles/generators.ts
+++ b/src/commands/add/misc/defaultStyles/generators.ts
@@ -161,7 +161,11 @@ export const createAppLayoutFile = async () => {
   if (!layoutExists) await createFile(layoutPath, defaultAppLayout);
 };
 
-const defaultAuthLayout = `import { getUserAuth } from "@/lib/auth/utils";
+const defaultAuthLayout = (authUtils: string) => `
+import { getUserAuth } from "${formatFilePath(authUtils, {
+  removeExtension: true,
+  prefix: "alias",
+})}";
 import { redirect } from "next/navigation";
 
 export default async function AuthLayout({
@@ -185,7 +189,8 @@ export const createAuthLayoutFile = async () => {
 
   const layoutExists = existsSync(layoutPath);
 
-  if (!layoutExists) await createFile(layoutPath, defaultAuthLayout);
+  if (!layoutExists)
+    await createFile(layoutPath, defaultAuthLayout(shared.auth.authUtils));
 };
 
 const landingPage = `/**

--- a/src/commands/add/misc/defaultStyles/generators.ts
+++ b/src/commands/add/misc/defaultStyles/generators.ts
@@ -149,10 +149,10 @@ const defaultAppLayout = `export default async function AppLayout({
   return ( <main>{children}</main> )
 }`;
 
-export const createAppLayoutFile = () => {
+export const createAppLayoutFile = async () => {
   const { shared } = getFilePaths();
 
-  createFile(
+  await createFile(
     formatFilePath(shared.init.appLayout, {
       prefix: "rootPath",
       removeExtension: false,
@@ -176,10 +176,10 @@ export default async function AuthLayout({
 }
 `;
 
-export const createAuthLayoutFile = () => {
+export const createAuthLayoutFile = async () => {
   const { shared } = getFilePaths();
 
-  createFile(
+  await createFile(
     formatFilePath(shared.auth.layoutPage, {
       prefix: "rootPath",
       removeExtension: false,
@@ -373,8 +373,8 @@ function MountainIcon(props: any) {
 }
 `;
 
-export const createLandingPage = () => {
-  replaceFile(
+export const createLandingPage = async () => {
+  await replaceFile(
     formatFilePath("app/page.tsx", {
       prefix: "rootPath",
       removeExtension: false,

--- a/src/commands/add/misc/navbar/generators.ts
+++ b/src/commands/add/misc/navbar/generators.ts
@@ -6,11 +6,11 @@
 import { createFile, readConfigFile } from "../../../../utils.js";
 import { formatFilePath, getFilePaths } from "../../../filePaths/index.js";
 
-export const addNavbarAndSettings = () => {
+export const addNavbarAndSettings = async () => {
   const { componentLib } = readConfigFile();
 
   // create navbar
-  createFile(
+  await createFile(
     formatFilePath("components/Navbar.tsx", {
       removeExtension: false,
       prefix: "rootPath",
@@ -19,7 +19,7 @@ export const addNavbarAndSettings = () => {
   );
 
   // create sidebar
-  createFile(
+  await createFile(
     formatFilePath("components/Sidebar.tsx", {
       removeExtension: false,
       prefix: "rootPath",
@@ -28,7 +28,7 @@ export const addNavbarAndSettings = () => {
   );
 
   // create sidebaritems
-  createFile(
+  await createFile(
     formatFilePath("components/SidebarItems.tsx", {
       removeExtension: false,
       prefix: "rootPath",
@@ -37,7 +37,7 @@ export const addNavbarAndSettings = () => {
   );
 
   // create sidebaritems
-  createFile(
+  await createFile(
     formatFilePath("config/nav.ts", {
       removeExtension: false,
       prefix: "rootPath",
@@ -48,7 +48,7 @@ export const addNavbarAndSettings = () => {
   // create settings page
 
   if (componentLib === "shadcn-ui")
-    createFile(
+    await createFile(
       formatFilePath("app/(app)/settings/page.tsx", {
         removeExtension: false,
         prefix: "rootPath",

--- a/src/commands/add/misc/resend/generators.ts
+++ b/src/commands/add/misc/resend/generators.ts
@@ -173,7 +173,7 @@ const generateApiRoute = () => {
   const { resend } = getFilePaths();
   return `import { EmailTemplate } from "${formatFilePath(
     resend.firstEmailComponent,
-    { prefix: "alias", removeExtension: true },
+    { prefix: "alias", removeExtension: true }
   )}";
 import { resend } from "${formatFilePath(resend.libEmailIndex, {
     prefix: "alias",
@@ -212,7 +212,7 @@ const generateEmailIndexTs = () => {
   return `import { Resend } from "resend";
 import { env } from "${formatFilePath(init.envMjs, {
     prefix: "alias",
-    removeExtension: true,
+    removeExtension: false,
   })}";
 
 export const resend = new Resend(env.RESEND_API_KEY);

--- a/src/commands/add/misc/resend/index.ts
+++ b/src/commands/add/misc/resend/index.ts
@@ -1,8 +1,6 @@
-import { consola } from "consola";
 import {
   addPackageToConfig,
   createFile,
-  installPackages,
   readConfigFile,
 } from "../../../../utils.js";
 import { AvailablePackage } from "../../../../types.js";
@@ -19,6 +17,7 @@ export const addResend = async (packagesBeingInstalled: AvailablePackage[]) => {
     rootPath,
   } = readConfigFile();
   const { resend } = getFilePaths();
+
   // const packages = packagesBeingInstalled.concat(installedPackages);
   // consola.start("Installing Resend...");
 
@@ -31,7 +30,7 @@ export const addResend = async (packagesBeingInstalled: AvailablePackage[]) => {
   } = resendGenerators;
 
   // 1. Add page at app/resend/page.tsx
-  createFile(
+  await createFile(
     formatFilePath(resend.resendPage, {
       prefix: "rootPath",
       removeExtension: false,
@@ -40,7 +39,7 @@ export const addResend = async (packagesBeingInstalled: AvailablePackage[]) => {
   );
 
   // 2. Add component at components/emails/FirstEmailTemplate.tsx
-  createFile(
+  await createFile(
     formatFilePath(resend.firstEmailComponent, {
       prefix: "rootPath",
       removeExtension: false,
@@ -48,7 +47,7 @@ export const addResend = async (packagesBeingInstalled: AvailablePackage[]) => {
     generateEmailTemplateComponent()
   );
   // 3. Add route handler at app/api/email/route.ts
-  createFile(
+  await createFile(
     formatFilePath(resend.emailApiRoute, {
       prefix: "rootPath",
       removeExtension: false,
@@ -57,7 +56,7 @@ export const addResend = async (packagesBeingInstalled: AvailablePackage[]) => {
   );
 
   // 4. Add email utils
-  createFile(
+  await createFile(
     formatFilePath(resend.emailUtils, {
       prefix: "rootPath",
       removeExtension: false,
@@ -66,7 +65,7 @@ export const addResend = async (packagesBeingInstalled: AvailablePackage[]) => {
   );
 
   // 5. add email index.ts
-  createFile(
+  await createFile(
     formatFilePath(resend.libEmailIndex, {
       prefix: "rootPath",
       removeExtension: false,
@@ -75,7 +74,7 @@ export const addResend = async (packagesBeingInstalled: AvailablePackage[]) => {
   );
 
   // 6. Add items to .env
-  addToDotEnv([{ key: "RESEND_API_KEY", value: "" }], rootPath, true);
+  await addToDotEnv([{ key: "RESEND_API_KEY", value: "" }], rootPath, true);
   // 7. Install packages (resend)
   // await installPackages(
   //   {
@@ -89,6 +88,6 @@ export const addResend = async (packagesBeingInstalled: AvailablePackage[]) => {
   if (orm === null)
     addToInstallList({ regular: ["zod", "@t3-oss/env-nextjs"], dev: [] });
 
-  addPackageToConfig("resend");
+  await addPackageToConfig("resend");
   // consola.success("Resend successfully installed and configured.");
 };

--- a/src/commands/add/misc/stripe/index.ts
+++ b/src/commands/add/misc/stripe/index.ts
@@ -16,8 +16,6 @@ import path from "path";
 import {
   addPackageToConfig,
   createFile,
-  getFileLocations,
-  installPackages,
   readConfigFile,
   replaceFile,
   updateConfigFile,
@@ -56,7 +54,6 @@ import { AuthSubTypeMapping, addToInstallList } from "../../utils.js";
 export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
   const {
     componentLib,
-    preferredPackageManager,
     rootPath,
     orm,
     driver,
@@ -71,7 +68,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
 
   if (orm === null || orm === undefined || driver === undefined) {
     consola.warn("You cannot install Stripe without an ORM installed.");
-    updateConfigFile({ orm: undefined });
+    await updateConfigFile({ orm: undefined });
     await addPackage();
     return;
   }
@@ -83,7 +80,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
 
     const authUtilsExist = existsSync(authUtilsPath);
     if (!authUtilsExist) {
-      createFile(authUtilsPath, libAuthUtilsTsWithoutAuthOptions());
+      await createFile(authUtilsPath, libAuthUtilsTsWithoutAuthOptions());
     }
   }
 
@@ -93,7 +90,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
 
   // add attributes to usermodel
   if (orm === "prisma") {
-    addToPrismaSchema(
+    await addToPrismaSchema(
       `model Subscription {
   userId                 String    @unique${
     authSubtype !== "managed"
@@ -115,7 +112,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
     }
   }
   if (orm === "drizzle") {
-    createFile(
+    await createFile(
       formatFilePath(stripe.subscriptionSchema, {
         prefix: "rootPath",
         removeExtension: false,
@@ -123,12 +120,12 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
       generateSubscriptionsDrizzleSchema(driver, auth)
     );
     if (t3) {
-      updateRootSchema("subscriptions");
+      await updateRootSchema("subscriptions");
     }
   }
 
   // create stripe/index file
-  createFile(
+  await createFile(
     formatFilePath(stripe.stripeIndex, {
       prefix: "rootPath",
       removeExtension: false,
@@ -136,7 +133,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
     generateStripeIndexTs()
   );
   // create stripe/subscription file
-  createFile(
+  await createFile(
     formatFilePath(stripe.stripeSubscription, {
       prefix: "rootPath",
       removeExtension: false,
@@ -144,7 +141,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
     generateStripeSubscriptionTs()
   );
   // create config/subscriptions.ts
-  createFile(
+  await createFile(
     formatFilePath(stripe.configSubscription, {
       prefix: "rootPath",
       removeExtension: false,
@@ -152,7 +149,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
     generateConfigSubscriptionsTs()
   );
   // components: create billing card
-  createFile(
+  await createFile(
     formatFilePath(stripe.accountPlanSettingsComponent, {
       prefix: "rootPath",
       removeExtension: false,
@@ -160,7 +157,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
     generateBillingCard()
   );
   // components: create manage subscription button
-  createFile(
+  await createFile(
     formatFilePath(stripe.billingManageSubscriptionComponent, {
       prefix: "rootPath",
       removeExtension: false,
@@ -169,7 +166,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
   );
   // components: create success toast
   if (componentLib === "shadcn-ui")
-    createFile(
+    await createFile(
       formatFilePath(stripe.billingSuccessToast, {
         prefix: "rootPath",
         removeExtension: false,
@@ -178,7 +175,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
     );
 
   // add billingcard to accountpage with billing card TODO
-  replaceFile(
+  await replaceFile(
     formatFilePath(shared.auth.accountPage, {
       prefix: "rootPath",
       removeExtension: false,
@@ -186,7 +183,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
     createAccountPage(true)
   );
   // create account/billing/page.tsx
-  createFile(
+  await createFile(
     formatFilePath(stripe.accountBillingPage, {
       prefix: "rootPath",
       removeExtension: false,
@@ -194,7 +191,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
     generateBillingPage()
   );
   // create api/webhooks/route.ts
-  createFile(
+  await createFile(
     formatFilePath(stripe.stripeWebhooksApiRoute, {
       prefix: "rootPath",
       removeExtension: false,
@@ -202,7 +199,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
     generateStripeWebhook()
   );
   // create api/billing/manage-subscription/route.ts
-  createFile(
+  await createFile(
     formatFilePath(stripe.manageSubscriptionApiRoute, {
       prefix: "rootPath",
       removeExtension: false,
@@ -213,7 +210,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
   addUtilToUtilsTs(rootPath);
 
   // add to dotenv
-  addToDotEnv(
+  await addToDotEnv(
     [
       { key: "STRIPE_SECRET_KEY", value: "" },
       { key: "STRIPE_WEBHOOK_SECRET", value: "" },
@@ -226,7 +223,7 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
   );
 
   // misc script updates
-  addListenScriptToPackageJson();
+  await addListenScriptToPackageJson();
   // install packages
   // await installPackages(
   //   { dev: "", regular: "stripe @stripe/stripe-js lucide-react" },
@@ -238,10 +235,10 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
     dev: [],
   });
 
-  addPackageToConfig("stripe");
+  await addPackageToConfig("stripe");
 
   if (packages.includes("trpc")) {
-    createFile(
+    await createFile(
       formatFilePath(stripe.accountRouterTrpc, {
         removeExtension: false,
         prefix: "rootPath",
@@ -249,11 +246,11 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
       createAccountTRPCRouter()
     );
     // add to main trpc router
-    updateTRPCRouter("account");
+    await updateTRPCRouter("account");
   }
 };
 
-const addListenScriptToPackageJson = () => {
+const addListenScriptToPackageJson = async () => {
   // Define the path to package.json
   const packageJsonPath = path.resolve("package.json");
 
@@ -276,12 +273,12 @@ const addListenScriptToPackageJson = () => {
   const updatedPackageJsonData = JSON.stringify(packageJson, null, 2);
 
   // Write the updated content back to package.json
-  replaceFile(packageJsonPath, updatedPackageJsonData);
+  await replaceFile(packageJsonPath, updatedPackageJsonData);
 
   // consola.success("Stripe listen script added to package.json");
 };
 
-const addUtilToUtilsTs = (rootPath: string) => {
+const addUtilToUtilsTs = async (rootPath: string) => {
   const { shared } = getFilePaths();
   const utilContentToAdd = `export function absoluteUrl(path: string) {
   return \`\${
@@ -297,9 +294,9 @@ const addUtilToUtilsTs = (rootPath: string) => {
     const utilsContent = fs.readFileSync(utilsPath, "utf-8");
     if (!utilsContent.includes(utilContentToAdd)) {
       const newUtilsContent = utilsContent.concat(`\n${utilContentToAdd}`);
-      replaceFile(utilsPath, newUtilsContent);
+      await replaceFile(utilsPath, newUtilsContent);
     } else return;
   } else {
-    createFile(utilsPath, utilContentToAdd);
+    await createFile(utilsPath, utilContentToAdd);
   }
 };

--- a/src/commands/add/misc/stripe/index.ts
+++ b/src/commands/add/misc/stripe/index.ts
@@ -50,6 +50,7 @@ import { formatFilePath, getFilePaths } from "../../../filePaths/index.js";
 import { libAuthUtilsTsWithoutAuthOptions } from "../../auth/next-auth/generators.js";
 import { updateRootSchema } from "../../../generate/generators/model/utils.js";
 import { AuthSubTypeMapping, addToInstallList } from "../../utils.js";
+import { addToSupabaseIgnoredRoutes } from "../../auth/supabase/utils.js";
 
 export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
   const {
@@ -86,6 +87,11 @@ export const addStripe = async (packagesBeingInstalled: AvailablePackage[]) => {
 
   if (auth === "clerk") {
     addToClerkIgnoredRoutes("/api/webhooks/stripe");
+  }
+
+  // TODO: Find out if this is actually necessary for Supabase
+  if (auth === "supabase") {
+    addToSupabaseIgnoredRoutes("/api/webhooks/stripe");
   }
 
   // add attributes to usermodel

--- a/src/commands/add/misc/trpc/index.ts
+++ b/src/commands/add/misc/trpc/index.ts
@@ -24,7 +24,7 @@ export const addTrpc = async () => {
   const { orm } = readConfigFile();
   const { trpc } = getFilePaths();
   // 1. Create lib/server/index.ts
-  createFile(
+  await createFile(
     formatFilePath(trpc.rootRouter, {
       prefix: "rootPath",
       removeExtension: false,
@@ -33,7 +33,7 @@ export const addTrpc = async () => {
   );
 
   // 2. create lib/server/trpc.ts
-  createFile(
+  await createFile(
     formatFilePath(trpc.serverTrpc, {
       prefix: "rootPath",
       removeExtension: false,
@@ -42,7 +42,7 @@ export const addTrpc = async () => {
   );
   // 3. create lib/server/router/ directory and maybe a users file
   // TODO : T3 COMPATABILITY
-  createFile(
+  await createFile(
     formatFilePath(`lib/server/routers/computers.ts`, {
       prefix: "rootPath",
       removeExtension: false,
@@ -50,7 +50,7 @@ export const addTrpc = async () => {
     serverRouterComputersTs()
   );
   // 4. create app/api/trpc/[trpc]/route.ts
-  createFile(
+  await createFile(
     formatFilePath(trpc.trpcApiRoute, {
       prefix: "rootPath",
       removeExtension: false,
@@ -58,7 +58,7 @@ export const addTrpc = async () => {
     apiTrpcRouteTs()
   );
   // 5. create lib/trpc/client.ts
-  createFile(
+  await createFile(
     formatFilePath(trpc.trpcClient, {
       prefix: "rootPath",
       removeExtension: false,
@@ -66,7 +66,7 @@ export const addTrpc = async () => {
     libTrpcClientTs()
   );
   // 6. create lib/trpc/Provider.tsx
-  createFile(
+  await createFile(
     formatFilePath(trpc.trpcProvider, {
       prefix: "rootPath",
       removeExtension: false,
@@ -74,8 +74,8 @@ export const addTrpc = async () => {
     libTrpcProviderTsx()
   );
   // 7. create lib/trpc/serverClient.ts -> updated to lib/trpc/api.ts using server invoker
-  // createFile(`${rootPath}/lib/trpc/serverClient.ts`, libTrpcServerClientTs());
-  createFile(
+  // await createFile(`${rootPath}/lib/trpc/serverClient.ts`, libTrpcServerClientTs());
+  await createFile(
     formatFilePath(trpc.trpcApiTs, {
       prefix: "rootPath",
       removeExtension: false,
@@ -85,7 +85,7 @@ export const addTrpc = async () => {
   );
 
   // 7.5. create context file and update to include context file above
-  createFile(
+  await createFile(
     formatFilePath(trpc.trpcContext, {
       prefix: "rootPath",
       removeExtension: false,
@@ -94,7 +94,7 @@ export const addTrpc = async () => {
   );
 
   // create trpc utils file lib/trpc/utils.ts
-  createFile(
+  await createFile(
     formatFilePath(trpc.trpcUtils, {
       prefix: "rootPath",
       removeExtension: false,
@@ -127,10 +127,10 @@ export const addTrpc = async () => {
   });
   if (orm === null) addToInstallList({ regular: ["zod"], dev: [] });
 
-  addPackageToConfig("trpc");
+  await addPackageToConfig("trpc");
   // 9. Instruct user to add the <Provider /> to their root layout.
-  addContextProviderToAppLayout("TrpcProvider");
-  // addToDotEnv(
+  await addContextProviderToAppLayout("TrpcProvider");
+  // await addToDotEnv(
   //   [
   //     {
   //       key: "VERCEL_URL",

--- a/src/commands/add/orm/drizzle/generators.ts
+++ b/src/commands/add/orm/drizzle/generators.ts
@@ -1,12 +1,6 @@
-import { consola } from "consola";
 import fs from "fs";
 import path from "path";
-import {
-  createFile,
-  installPackages,
-  readConfigFile,
-  replaceFile,
-} from "../../../../utils.js";
+import { createFile, readConfigFile, replaceFile } from "../../../../utils.js";
 import {
   DBProvider,
   DBType,
@@ -18,10 +12,11 @@ import {
   formatFilePath,
   getDbIndexPath,
   getFilePaths,
-  removeFileExtension,
 } from "../../../filePaths/index.js";
 import stripJsonComments from "strip-json-comments";
 import { addToInstallList } from "../../utils.js";
+import { formatFileContentWithPrettier } from "../../../init/utils.js";
+// import consola from "consola";
 
 type ConfigDriver = "pg" | "turso" | "libsql" | "mysql" | "better-sqlite";
 
@@ -38,13 +33,16 @@ const configDriverMappings = {
   turso: "turso",
 };
 
-export const createDrizzleConfig = (libPath: string, provider: DBProvider) => {
+export const createDrizzleConfig = async (
+  libPath: string,
+  provider: DBProvider
+) => {
   const {
     shared: {
       init: { envMjs },
     },
   } = getFilePaths();
-  createFile(
+  await createFile(
     "drizzle.config.ts",
     `import type { Config } from "drizzle-kit";
 import { env } from "${formatFilePath(envMjs, {
@@ -72,12 +70,11 @@ export default {
   );
 };
 
-export const createIndexTs = (dbProvider: DBProvider) => {
+export const createIndexTs = async (dbProvider: DBProvider) => {
   const {
     shared: {
       init: { envMjs },
     },
-    drizzle,
   } = getFilePaths();
   const dbIndex = getDbIndexPath("drizzle");
   let indexTS = "";
@@ -228,13 +225,13 @@ export const db = drizzle(sqlite);
       break;
   }
 
-  createFile(
+  await createFile(
     formatFilePath(dbIndex, { prefix: "rootPath", removeExtension: false }),
     indexTS
   );
 };
 
-export const createMigrateTs = (
+export const createMigrateTs = async (
   libPath: string,
   dbType: DBType,
   dbProvider: DBProvider
@@ -424,13 +421,13 @@ runMigrate().catch((err) => {
   process.exit(1);
 });`;
 
-  createFile(
+  await createFile(
     formatFilePath(dbMigrate, { prefix: "rootPath", removeExtension: false }),
     template
   );
 };
 
-export const createInitSchema = (libPath?: string, dbType?: DBType) => {
+export const createInitSchema = async (libPath?: string, dbType?: DBType) => {
   const { packages, driver, rootPath } = readConfigFile();
   const {
     shared: {
@@ -518,10 +515,10 @@ export type NewComputer = z.infer<typeof insertComputerSchema>;
 export type ComputerId = z.infer<typeof computerIdSchema>["id"];`;
 
   const finalDoc = `${sharedImports}\n${initModel}\n${sharedSchemas}`;
-  createFile(path, finalDoc);
+  await createFile(path, finalDoc);
 };
 
-export const addScriptsToPackageJson = (
+export const addScriptsToPackageJson = async (
   libPath: string,
   driver: DBType,
   preferredPackageManager: PMType
@@ -553,7 +550,10 @@ export const addScriptsToPackageJson = (
   const updatedPackageJsonData = JSON.stringify(packageJson, null, 2);
 
   // Write the updated content back to package.json
-  fs.writeFileSync(packageJsonPath, updatedPackageJsonData);
+  fs.writeFileSync(
+    packageJsonPath,
+    await formatFileContentWithPrettier(updatedPackageJsonData, packageJsonPath)
+  );
 
   // consola.success("Scripts added to package.json");
 };
@@ -604,7 +604,7 @@ export const installDependencies = async (
   }
 };
 
-export const createDotEnv = (
+export const createDotEnv = async (
   orm: ORMType,
   preferredPackageManager: PMType,
   databaseUrl?: string,
@@ -622,25 +622,32 @@ export const createDotEnv = (
   const envPath = path.resolve(".env");
   const envExists = fs.existsSync(envPath);
   if (!envExists)
-    createFile(
+    await createFile(
       ".env",
       `${
         orm === "drizzle" && usingPlanetscale
           ? `# When using the PlanetScale driver with Drizzle, your connection string must end with ?ssl={"rejectUnauthorized":true} instead of ?sslaccept=strict.\n`
           : ""
-      }DATABASE_URL=${dburl}`
+      }DATABASE_URL=${dburl}`,
+      true
     );
 
   const envmjsfilePath = formatFilePath(envMjs, {
     prefix: "rootPath",
     removeExtension: false,
   });
+
   const envMjsExists = fs.existsSync(envmjsfilePath);
+
   if (!envMjsExists)
-    createFile(envmjsfilePath, generateEnvMjs(preferredPackageManager, orm));
+    await createFile(
+      envmjsfilePath,
+      generateEnvMjs(preferredPackageManager, orm),
+      false
+    );
 };
 
-export const addToDotEnv = (
+export const addToDotEnv = async (
   items: DotEnvItem[],
   rootPathOld?: string,
   excludeDbUrlIfBlank = false
@@ -651,17 +658,23 @@ export const addToDotEnv = (
       init: { envMjs },
     },
   } = getFilePaths();
+
   // handling dotenv
   const envPath = path.resolve(".env");
   const envExists = fs.existsSync(envPath);
   const newData = items.map((item) => `${item.key}=${item.value}`).join("\n");
+  let content = newData;
+
   if (envExists) {
     const envData = fs.readFileSync(envPath, "utf-8");
-    const updatedEnvData = `${envData}\n${newData}`;
-    fs.writeFileSync(envPath, updatedEnvData);
-  } else {
-    fs.writeFileSync(envPath, newData);
+    content = `${envData}\n${newData}`;
   }
+
+  fs.writeFileSync(
+    envPath,
+    await formatFileContentWithPrettier(content, envPath, true)
+  );
+
   // handling env.mjs
   const envmjsfilePath = formatFilePath(envMjs, {
     removeExtension: false,
@@ -672,10 +685,11 @@ export const addToDotEnv = (
     return;
   }
   if (!envMjsExists)
-    createFile(
+    await createFile(
       envmjsfilePath,
       generateEnvMjs(preferredPackageManager, orm, excludeDbUrlIfBlank)
     );
+
   let envmjsfileContents = fs.readFileSync(envmjsfilePath, "utf-8");
 
   const formatItemForDotEnvMjs = (item: DotEnvItem) =>
@@ -700,20 +714,33 @@ export const addToDotEnv = (
     .map(formatPublicItemForRuntimeEnv)
     .join("\n    ");
 
+  const regex = /\s*},\n\s*client:\s*{\n/;
+
+  const endofClientIndex = envmjsfileContents.match(regex);
+  const beforeClientBlockEnd = envmjsfileContents.lastIndexOf(
+    "\n",
+    endofClientIndex.index
+  );
+  const endOfClientBlock = envmjsfileContents.slice(0, beforeClientBlockEnd);
+  const hasCommaBeforeClient = endOfClientBlock.endsWith(",");
+
   // Construct the replacement string for both server and client sections
-  const replacementStr = `    ${serverItems}\n  },\n  client: {\n    ${clientItems}`;
+  const replacementStr = `${hasCommaBeforeClient ? "" : ","}\n    ${serverItems}\n  },\n  client: {\n    ${clientItems}\n`;
 
   // Replace content using the known pattern
-  const regex = /  },\n  client: {\n/s;
   envmjsfileContents = envmjsfileContents.replace(regex, replacementStr);
 
   const runtimeEnvRegex = /experimental__runtimeEnv: {\n/s;
   envmjsfileContents = envmjsfileContents.replace(
     runtimeEnvRegex,
-    `experimental__runtimeEnv: {\n    ${runtimeEnvItems}`
+    `experimental__runtimeEnv: {\n    ${runtimeEnvItems}\n`
   );
+
   // Write the updated contents back to the file
-  fs.writeFileSync(envmjsfilePath, envmjsfileContents);
+  fs.writeFileSync(
+    envmjsfilePath,
+    await formatFileContentWithPrettier(envmjsfileContents, envmjsfilePath)
+  );
 };
 
 export async function updateTsConfigTarget() {
@@ -721,7 +748,7 @@ export async function updateTsConfigTarget() {
   const tsConfigPath = path.join(process.cwd(), "tsconfig.json");
 
   // Read the file
-  fs.readFile(tsConfigPath, "utf8", (err, data) => {
+  fs.readFile(tsConfigPath, "utf8", async (err, data) => {
     if (err) {
       console.error(
         `An error occurred while reading the tsconfig.json file: ${err}`
@@ -740,14 +767,14 @@ export async function updateTsConfigTarget() {
     const updatedContent = JSON.stringify(tsConfig, null, 2); // 2 spaces indentation
 
     // Write the updated content back to the file
-    replaceFile(tsConfigPath, updatedContent);
+    await replaceFile(tsConfigPath, updatedContent);
     // consola.success(
     //   "Updated tsconfig.json target to esnext to support Drizzle-Kit."
     // );
   });
 }
 
-export function createQueriesAndMutationsFolders(
+export async function createQueriesAndMutationsFolders(
   libPath: string,
   driver: DBType
 ) {
@@ -837,14 +864,14 @@ export const deleteComputer = async (id: ComputerId) => {
     throw { error: message };
   }
 };`;
-  createFile(
+  await createFile(
     formatFilePath("lib/api/computers/queries.ts", {
       removeExtension: false,
       prefix: "rootPath",
     }),
     query
   );
-  createFile(
+  await createFile(
     formatFilePath("lib/api/computers/mutations.ts", {
       prefix: "rootPath",
       removeExtension: false,
@@ -870,20 +897,19 @@ export const env = createEnv({
     NODE_ENV: z
       .enum(["development", "test", "production"])
       .default("development"),
-    ${blank ? "// " : ""}DATABASE_URL: z.string().min(1),
-    
+    ${blank ? "// " : ""}DATABASE_URL: z.string().min(1)
   },
   client: {
-    // NEXT_PUBLIC_PUBLISHABLE_KEY: z.string().min(1),
+    // NEXT_PUBLIC_PUBLISHABLE_KEY: z.string().min(1)
   },
   // If you're using Next.js < 13.4.4, you'll need to specify the runtimeEnv manually
   // runtimeEnv: {
   //   DATABASE_URL: process.env.DATABASE_URL,
-  //   NEXT_PUBLIC_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_PUBLISHABLE_KEY,
+  //   NEXT_PUBLIC_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_PUBLISHABLE_KEY
   // },
   // For Next.js >= 13.4.4, you only need to destructure client variables:
   experimental__runtimeEnv: {
-    // NEXT_PUBLIC_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_PUBLISHABLE_KEY,
+    // NEXT_PUBLIC_PUBLISHABLE_KEY: process.env.NEXT_PUBLIC_PUBLISHABLE_KEY
   },
 });
 `;

--- a/src/commands/add/orm/drizzle/index.ts
+++ b/src/commands/add/orm/drizzle/index.ts
@@ -48,21 +48,21 @@ export const addDrizzle = async (
   // create all the files here
 
   if (includeExampleModel) {
-    createInitSchema(libPath, dbType);
-    createQueriesAndMutationsFolders(libPath, dbType);
+    await createInitSchema(libPath, dbType);
+    await createQueriesAndMutationsFolders(libPath, dbType);
   } else {
     createFolder(`${hasSrc ? "src/" : ""}lib/db/schema`);
     createFolder(`${hasSrc ? "src/" : ""}lib/api`);
   }
 
   // dependent on dbtype and driver, create
-  createIndexTs(dbProvider);
-  createMigrateTs(libPath, dbType, dbProvider);
-  createDrizzleConfig(libPath, dbProvider);
+  await createIndexTs(dbProvider);
+  await createMigrateTs(libPath, dbType, dbProvider);
+  await createDrizzleConfig(libPath, dbProvider);
 
   // perhaps using push rather than migrate for sqlite?
   addScriptsToPackageJson(libPath, dbType, preferredPackageManager);
-  createDotEnv(
+  await createDotEnv(
     "drizzle",
     preferredPackageManager,
     databaseUrl,
@@ -70,7 +70,7 @@ export const addDrizzle = async (
     hasSrc ? "src/" : ""
   );
   if (dbProvider === "vercel-pg")
-    addToDotEnv(
+    await addToDotEnv(
       [
         { key: "POSTGRES_URL", value: "" },
         { key: "POSTGRES_URL_NON_POOLING", value: "" },
@@ -82,13 +82,17 @@ export const addDrizzle = async (
       rootPath
     );
   if (dbProvider === "turso")
-    addToDotEnv([{ key: "DATABASE_AUTH_TOKEN", value: "" }], rootPath);
+    await addToDotEnv([{ key: "DATABASE_AUTH_TOKEN", value: "" }], rootPath);
 
   await updateTsConfigTarget();
 
-  addNanoidToUtils();
+  await addNanoidToUtils();
 
-  updateConfigFile({ driver: dbType, provider: dbProvider, orm: "drizzle" });
+  await updateConfigFile({
+    driver: dbType,
+    provider: dbProvider,
+    orm: "drizzle",
+  });
   await installDependencies(dbProvider, preferredPackageManager);
-  addPackageToConfig("drizzle");
+  await addPackageToConfig("drizzle");
 };

--- a/src/commands/add/orm/drizzle/utils.ts
+++ b/src/commands/add/orm/drizzle/utils.ts
@@ -3,7 +3,7 @@ import { createFile, readConfigFile, replaceFile } from "../../../../utils.js";
 import { consola } from "consola";
 import { formatFilePath, getFilePaths } from "../../../filePaths/index.js";
 
-export function addToDrizzleModel(
+export async function addToDrizzleModel(
   modelName: string,
   attributesToAdd: string,
   additionalImports?: string[]
@@ -31,7 +31,7 @@ export function addToDrizzleModel(
       '} from "drizzle-orm',
       `${additionalImports.map((i) => `, ${i}`)} } from "drizzle-orm`
     );
-    replaceFile(pathToModel, newSchemaWithUpdatedImports);
+    await replaceFile(pathToModel, newSchemaWithUpdatedImports);
     consola.info("Updated Drizzle schema");
   }
 }
@@ -49,7 +49,7 @@ const getDrizzleModelStartAndEnd = (schema: string, modelName: string) => {
   return { modelStart, modelEnd, modelExists };
 };
 
-export const addNanoidToUtils = () => {
+export const addNanoidToUtils = async () => {
   const nanoidContent = `import { customAlphabet } from "nanoid";
 export const nanoid = customAlphabet("abcdefghijklmnopqrstuvwxyz0123456789");`;
   const { shared } = getFilePaths();
@@ -59,18 +59,18 @@ export const nanoid = customAlphabet("abcdefghijklmnopqrstuvwxyz0123456789");`;
   });
   const utilsExists = existsSync(utilsPath);
   if (!utilsExists) {
-    createFile(utilsPath, nanoidContent);
+    await createFile(utilsPath, nanoidContent);
   } else {
     const utilsContent = readFileSync(utilsPath, "utf-8");
     const newContent = `${nanoidContent.split("\n")[0].trim()}
 ${utilsContent}
 ${nanoidContent.split("\n")[1].trim()}
 `;
-    replaceFile(utilsPath, newContent);
+    await replaceFile(utilsPath, newContent);
   }
 };
 
-export const checkTimestampsInUtils = () => {
+export const checkTimestampsInUtils = async () => {
   const timestampsContent = `export const timestamps: { createdAt: true; updatedAt: true } = {
   createdAt: true,
   updatedAt: true,
@@ -83,14 +83,14 @@ export const checkTimestampsInUtils = () => {
   });
   const utilsExists = existsSync(utilsPath);
   if (!utilsExists) {
-    createFile(utilsPath, timestampsContent);
+    await createFile(utilsPath, timestampsContent);
   } else {
     const utilsContent = readFileSync(utilsPath, "utf-8");
     if (utilsContent.indexOf(timestampsContent) === -1) {
       const newContent = `${utilsContent}
-${timestampsContent}
-`;
-      replaceFile(utilsPath, newContent);
+  ${timestampsContent}
+  `;
+      await replaceFile(utilsPath, newContent);
     }
   }
 };

--- a/src/commands/add/orm/prisma/index.ts
+++ b/src/commands/add/orm/prisma/index.ts
@@ -1,10 +1,8 @@
-import { confirm, select } from "@inquirer/prompts";
 import { DBType, InitOptions } from "../../../../types.js";
 import {
   addPackageToConfig,
   createFile,
   createFolder,
-  installPackages,
   readConfigFile,
   updateConfigFile,
 } from "../../../../utils.js";
@@ -39,12 +37,15 @@ export const addPrisma = async (
   // if mysql, ask if planetscale
   if (dbType === "mysql") {
     // scaffold planetscale specific schema
-    createFile(
+    await createFile(
       `prisma/schema.prisma`,
-      generatePrismaSchema(dbType, initOptions.dbProvider === "planetscale")
+      await generatePrismaSchema(
+        dbType,
+        initOptions.dbProvider === "planetscale"
+      )
     );
-    updateConfigFile({ provider: "planetscale" });
-    createDotEnv(
+    await updateConfigFile({ provider: "planetscale" });
+    await createDotEnv(
       "prisma",
       preferredPackageManager,
       generateDbUrl(dbType),
@@ -53,8 +54,11 @@ export const addPrisma = async (
     );
   } else {
     // create prisma/schema.prisma (with db type)
-    createFile(`prisma/schema.prisma`, generatePrismaSchema(dbType, false));
-    createDotEnv(
+    await createFile(
+      `prisma/schema.prisma`,
+      await generatePrismaSchema(dbType, false)
+    );
+    await createDotEnv(
       "prisma",
       preferredPackageManager,
       generateDbUrl(dbType),
@@ -66,7 +70,7 @@ export const addPrisma = async (
   // create .env with database_url
 
   // generate prisma global instance
-  createFile(
+  await createFile(
     formatFilePath(dbIndex, {
       prefix: "rootPath",
       removeExtension: false,
@@ -80,7 +84,7 @@ export const addPrisma = async (
   // create all the files here
 
   if (includeExampleModel) {
-    addToPrismaSchema(
+    await addToPrismaSchema(
       `model Computer {
   id    String @id @default(cuid())
   brand String
@@ -89,17 +93,17 @@ export const addPrisma = async (
       "Computer"
     );
     // generate /lib/db/schema/computers.ts
-    createFile(
+    await createFile(
       `${rootPath}lib/db/schema/computers.ts`,
       generatePrismaComputerModel()
     );
 
     // generate /lib/api/computers/queries.ts && /lib/api/computers/mutations.ts
-    createFile(
+    await createFile(
       `${rootPath}lib/api/computers/queries.ts`,
       generatePrismaComputerQueries()
     );
-    createFile(
+    await createFile(
       `${rootPath}lib/api/computers/mutations.ts`,
       generatePrismaComputerMutations()
     );
@@ -108,7 +112,7 @@ export const addPrisma = async (
     createFolder(`${hasSrc ? "src/" : ""}lib/api`);
   }
 
-  addScriptsToPackageJsonForPrisma(dbType);
+  await addScriptsToPackageJsonForPrisma(dbType);
 
   // install packages: regular: [] dev: [prisma, zod-prisma]
   // await installPackages(
@@ -123,8 +127,8 @@ export const addPrisma = async (
   // run prisma generate
   if (includeExampleModel) await prismaGenerate(preferredPackageManager);
 
-  addPackageToConfig("prisma");
-  updateConfigFile({ orm: "prisma", driver: dbType });
+  await addPackageToConfig("prisma");
+  await updateConfigFile({ orm: "prisma", driver: dbType });
 
   // consola.success("Prisma has been added to your project!");
 };

--- a/src/commands/add/orm/prisma/utils.ts
+++ b/src/commands/add/orm/prisma/utils.ts
@@ -1,6 +1,7 @@
 import path from "path";
 import fs from "fs";
 import { DBType } from "../../../../types.js";
+import { formatFileContentWithPrettier } from "../../../init/utils.js";
 
 export const prismaDbTypeMappings: { [key in DBType]: string } = {
   pg: "postgresql",
@@ -8,7 +9,7 @@ export const prismaDbTypeMappings: { [key in DBType]: string } = {
   sqlite: "sqlite",
 };
 
-export const addScriptsToPackageJsonForPrisma = (driver: DBType) => {
+export const addScriptsToPackageJsonForPrisma = async (driver: DBType) => {
   // Define the path to package.json
   const packageJsonPath = path.resolve("package.json");
 
@@ -33,7 +34,10 @@ export const addScriptsToPackageJsonForPrisma = (driver: DBType) => {
   const updatedPackageJsonData = JSON.stringify(packageJson, null, 2);
 
   // Write the updated content back to package.json
-  fs.writeFileSync(packageJsonPath, updatedPackageJsonData);
+  fs.writeFileSync(
+    packageJsonPath,
+    await formatFileContentWithPrettier(updatedPackageJsonData, packageJsonPath)
+  );
 
   // consola.success("Scripts added to package.json");
 };

--- a/src/commands/add/orm/utils.ts
+++ b/src/commands/add/orm/utils.ts
@@ -72,6 +72,6 @@ export async function updateTsConfigPrismaTypeAlias() {
   const updatedContent = JSON.stringify(tsConfig, null, 2); // 2 spaces indentation
 
   // Write the updated content back to the file
-  replaceFile(tsConfigPath, updatedContent);
+  await replaceFile(tsConfigPath, updatedContent);
   // consola.success("Updated tsconfig.json to support zod-prisma type alias.");
 }

--- a/src/commands/add/utils.ts
+++ b/src/commands/add/utils.ts
@@ -35,6 +35,7 @@ export const Packages: {
     { name: "Clerk", value: "clerk" },
     { name: "Lucia", value: "lucia" },
     { name: "Kinde", value: "kinde" },
+    { name: "Supabase", value: "supabase" },
   ],
   misc: [
     { name: "TRPC", value: "trpc" },
@@ -44,7 +45,9 @@ export const Packages: {
   componentLib: [{ name: "Shadcn UI (with next-themes)", value: "shadcn-ui" }],
 };
 
-export const addContextProviderToRootLayout = (provider: "ThemeProvider") => {
+export const addContextProviderToRootLayout = async (
+  provider: "ThemeProvider"
+) => {
   const { hasSrc, alias } = readConfigFile();
   const path = `${hasSrc ? "src/" : ""}app/layout.tsx`;
 
@@ -87,10 +90,10 @@ export const addContextProviderToRootLayout = (provider: "ThemeProvider") => {
     searchValue,
     replacementText
   );
-  replaceFile(path, newLayoutContent);
+  await replaceFile(path, newLayoutContent);
 };
 
-export const addAuthCheckToAppLayout = () => {
+export const addAuthCheckToAppLayout = async () => {
   const { hasSrc } = readConfigFile();
   const path = `${hasSrc ? "src/" : ""}app/(app)/layout.tsx`;
   const { shared } = getFilePaths();
@@ -109,9 +112,9 @@ export const addAuthCheckToAppLayout = () => {
 `;
   const newText =
     importStatement + fileContent.replace(searchText, replacementText);
-  replaceFile(path, newText);
+  await replaceFile(path, newText);
 };
-export const addContextProviderToAppLayout = (
+export const addContextProviderToAppLayout = async (
   provider:
     | "NextAuthProvider"
     | "TrpcProvider"
@@ -205,10 +208,10 @@ export const addContextProviderToAppLayout = (
     searchValue,
     replacementText
   );
-  replaceFile(path, newLayoutContent);
+  await replaceFile(path, newLayoutContent);
 };
 
-export const addContextProviderToAuthLayout = (
+export const addContextProviderToAuthLayout = async (
   provider:
     | "NextAuthProvider"
     | "TrpcProvider"
@@ -279,7 +282,7 @@ export const addContextProviderToAuthLayout = (
     searchValue,
     replacementText
   );
-  replaceFile(path, newLayoutContent);
+  await replaceFile(path, newLayoutContent);
 };
 
 export const AuthSubTypeMapping: Record<AuthType, AuthSubType> = {
@@ -287,6 +290,7 @@ export const AuthSubTypeMapping: Record<AuthType, AuthSubType> = {
   kinde: "managed",
   "next-auth": "self-hosted",
   lucia: "managed",
+  supabase: "managed",
 };
 
 const installList: { regular: string[]; dev: string[] } = {
@@ -367,6 +371,9 @@ export const printNextSteps = (
       : []),
     ...(promptResponses.auth === "clerk"
       ? [`${chalk.underline("Authentication")}: Clerk`]
+      : []),
+    ...(promptResponses.auth === "supabase"
+      ? [`${chalk.underline("Authentication")}: Supabase`]
       : []),
     ...(promptResponses.auth === "lucia"
       ? [`${chalk.underline("Authentication")}: Lucia`]

--- a/src/commands/filePaths/index.ts
+++ b/src/commands/filePaths/index.ts
@@ -15,6 +15,7 @@ export const paths: { t3: Paths; normal: Paths } = {
         schemaDir: "lib/db/schema",
       },
       auth: {
+        authActions: "lib/auth/actions.ts",
         authUtils: "lib/auth/utils.ts",
         accountPage: "app/(app)/account/page.tsx",
         authSchema: "lib/db/schema/auth.ts",
@@ -71,7 +72,7 @@ export const paths: { t3: Paths; normal: Paths } = {
       signUpPage: "app/(auth)/sign-up/page.tsx",
       signOutButtonComponent: "components/auth/SignOutBtn.tsx",
       callbackApiRoute: "app/api/auth/callback/route.ts",
-      libAuthSupabase: "lib/supabase/auth/index.ts",
+      libSupabaseAuthHelpers: "lib/supabase/auth/helper.ts",
       middleware: "middleware.ts",
     },
     kinde: {
@@ -121,6 +122,7 @@ export const paths: { t3: Paths; normal: Paths } = {
         schemaDir: "server/db/schema",
       },
       auth: {
+        authActions: "lib/auth/actions.ts",
         authUtils: "lib/auth/utils.ts",
         accountPage: "app/(app)/account/page.tsx",
         authSchema: "server/db/schema/auth.ts",
@@ -177,7 +179,7 @@ export const paths: { t3: Paths; normal: Paths } = {
       signUpPage: "app/(auth)/sign-up/page.tsx",
       signOutButtonComponent: "components/auth/SignOutBtn.tsx",
       callbackApiRoute: "app/api/auth/callback/route.ts",
-      libAuthSupabase: "lib/supabase/auth/index.ts",
+      libSupabaseAuthHelpers: "lib/supabase/auth/helper.ts",
       middleware: "middleware.ts",
     },
     kinde: {

--- a/src/commands/filePaths/index.ts
+++ b/src/commands/filePaths/index.ts
@@ -95,6 +95,7 @@ export const paths: { t3: Paths; normal: Paths } = {
       signOutButtonComponent: "components/auth/SignOutBtn.tsx",
       nextAuthApiRoute: "app/api/auth/[...nextauth]/route.ts",
       authProviderComponent: "lib/auth/Provider.tsx",
+      signInPage: "app/(auth)/sign-in/page.tsx",
     },
   },
   t3: {
@@ -191,6 +192,7 @@ export const paths: { t3: Paths; normal: Paths } = {
       signOutButtonComponent: "components/auth/SignOutBtn.tsx",
       nextAuthApiRoute: "app/api/auth/[...nextauth]/route.ts",
       authProviderComponent: "lib/auth/Provider.tsx",
+      signInPage: "app/(auth)/sign-in/page.tsx",
     },
   },
 };

--- a/src/commands/filePaths/index.ts
+++ b/src/commands/filePaths/index.ts
@@ -65,6 +65,15 @@ export const paths: { t3: Paths; normal: Paths } = {
       authFormComponent: "components/auth/Form.tsx",
       signOutButtonComponent: "components/auth/SignOutBtn.tsx",
     },
+    supabase: {
+      authFormComponent: "components/auth/Form.tsx",
+      signInPage: "app/(auth)/sign-in/page.tsx",
+      signUpPage: "app/(auth)/sign-up/page.tsx",
+      signOutButtonComponent: "components/auth/SignOutBtn.tsx",
+      callbackApiRoute: "app/api/auth/callback/route.ts",
+      libAuthSupabase: "lib/supabase/auth/index.ts",
+      middleware: "middleware.ts",
+    },
     kinde: {
       routeHandler: "app/api/auth/[kindeAuth]/route.ts",
       signInPage: "app/(auth)/sign-in/page.tsx",
@@ -161,6 +170,15 @@ export const paths: { t3: Paths; normal: Paths } = {
       libAuthLucia: "lib/auth/lucia.ts",
       authFormComponent: "components/auth/Form.tsx",
       signOutButtonComponent: "components/auth/SignOutBtn.tsx",
+    },
+    supabase: {
+      authFormComponent: "components/auth/Form.tsx",
+      signInPage: "app/(auth)/sign-in/page.tsx",
+      signUpPage: "app/(auth)/sign-up/page.tsx",
+      signOutButtonComponent: "components/auth/SignOutBtn.tsx",
+      callbackApiRoute: "app/api/auth/callback/route.ts",
+      libAuthSupabase: "lib/supabase/auth/index.ts",
+      middleware: "middleware.ts",
     },
     kinde: {
       routeHandler: "app/api/auth/[kindeAuth]/route.ts",

--- a/src/commands/filePaths/types.d.ts
+++ b/src/commands/filePaths/types.d.ts
@@ -23,6 +23,7 @@ export type Paths = {
       schemaDir?: string;
     };
     auth: {
+      authActions: string;
       authUtils: string;
       signInComponent: string;
       accountApiRoute: string;
@@ -62,7 +63,7 @@ export type Paths = {
     signUpPage: string;
     authFormComponent: string;
     callbackApiRoute: string;
-    libAuthSupabase: string;
+    libSupabaseAuthHelpers: string;
     signOutButtonComponent: string;
     middleware: string;
   };

--- a/src/commands/filePaths/types.d.ts
+++ b/src/commands/filePaths/types.d.ts
@@ -57,6 +57,15 @@ export type Paths = {
     libAuthLucia: string;
     signOutButtonComponent: string;
   };
+  supabase: {
+    signInPage: string;
+    signUpPage: string;
+    authFormComponent: string;
+    callbackApiRoute: string;
+    libAuthSupabase: string;
+    signOutButtonComponent: string;
+    middleware: string;
+  };
   kinde: {
     routeHandler: string;
     signInPage: string;

--- a/src/commands/filePaths/types.d.ts
+++ b/src/commands/filePaths/types.d.ts
@@ -39,6 +39,7 @@ export type Paths = {
     nextAuthApiRoute: string;
     authProviderComponent: string;
     signOutButtonComponent: string;
+    signInPage: string;
   };
   clerk: {
     middleware: string;

--- a/src/commands/generate/generators/apiRoute.ts
+++ b/src/commands/generate/generators/apiRoute.ts
@@ -4,13 +4,13 @@ import { formatFilePath, getFilePaths } from "../../filePaths/index.js";
 import { Schema } from "../types.js";
 import { formatTableName, toCamelCase } from "../utils.js";
 
-export const scaffoldAPIRoute = (schema: Schema) => {
+export const scaffoldAPIRoute = async (schema: Schema) => {
   const { hasSrc, driver } = readConfigFile();
   const { tableName } = schema;
   const path = `${hasSrc ? "src/" : ""}app/api/${toCamelCase(
     tableName
   )}/route.ts`;
-  createFile(path, generateRouteContent(schema, driver));
+  await createFile(path, generateRouteContent(schema, driver));
 };
 
 const generateRouteContent = (schema: Schema, driver: DBType) => {

--- a/src/commands/generate/generators/model/index.ts
+++ b/src/commands/generate/generators/model/index.ts
@@ -1,8 +1,15 @@
-import { consola } from "consola";
+// import { consola } from "consola";
 import { DBType } from "../../../../types.js";
-import { createFile, readConfigFile, replaceFile } from "../../../../utils.js";
+import {
+  createFile,
+  readConfigFile,
+  // replaceFile
+} from "../../../../utils.js";
 import { prismaFormat, prismaGenerate } from "../../../add/orm/utils.js";
-import { ExtendedSchema, Schema } from "../../types.js";
+import {
+  ExtendedSchema,
+  // Schema
+} from "../../types.js";
 import { toCamelCase } from "../../utils.js";
 import { generateMutationContent } from "./mutations/index.js";
 import { generateQueryContent } from "./queries/index.js";
@@ -12,7 +19,7 @@ import {
   generateServiceFileNames,
   getFilePaths,
 } from "../../../filePaths/index.js";
-import { existsSync, readFileSync } from "fs";
+// import { existsSync, readFileSync } from "fs";
 import { updateRootSchema } from "./utils.js";
 
 export async function scaffoldModel(
@@ -22,17 +29,20 @@ export async function scaffoldModel(
 ) {
   const { tableName } = schema;
   const { orm, preferredPackageManager, driver, t3 } = readConfigFile();
-  const { shared, drizzle } = getFilePaths();
+  const {
+    shared,
+    // drizzle
+  } = getFilePaths();
   const serviceFileNames = generateServiceFileNames(toCamelCase(tableName));
 
   const modelPath = `${formatFilePath(shared.orm.schemaDir, {
     prefix: "rootPath",
     removeExtension: false,
   })}/${toCamelCase(tableName)}.ts`;
-  createFile(modelPath, generateModelContent(schema, dbType));
+  await createFile(modelPath, await generateModelContent(schema, dbType));
 
   if (t3 && orm === "drizzle") {
-    updateRootSchema(tableName);
+    await updateRootSchema(tableName);
   }
 
   if (orm === "prisma") {
@@ -41,10 +51,13 @@ export async function scaffoldModel(
   }
 
   // create queryFile
-  createFile(serviceFileNames.queriesPath, generateQueryContent(schema, orm));
+  await createFile(
+    serviceFileNames.queriesPath,
+    generateQueryContent(schema, orm)
+  );
 
   // create mutationFile
-  createFile(
+  await createFile(
     serviceFileNames.mutationsPath,
     generateMutationContent(schema, driver, orm)
   );

--- a/src/commands/generate/generators/model/schema/index.ts
+++ b/src/commands/generate/generators/model/schema/index.ts
@@ -300,7 +300,7 @@ const generateIndexFields = (
     .join("\n  ")}`;
 };
 
-const generatePrismaSchema = (
+const generatePrismaSchema = async (
   schema: Schema,
   mappings: TypeMap,
   zodSchemas: string,
@@ -332,22 +332,23 @@ const generatePrismaSchema = (
     schema.includeTimestamps ? generateTimestampFieldsPrisma() : ""
   }
 }`;
-  addToPrismaSchema(prismaSchemaContent, tableNameSingularCapitalised);
+  await addToPrismaSchema(prismaSchemaContent, tableNameSingularCapitalised);
   if (schema.belongsToUser && authSubtype === "self-hosted")
-    addToPrismaModel(
+    await addToPrismaModel(
       "User",
       `${tableNameCamelCase} ${tableNameSingularCapitalised}[]`
     );
 
-  relations.forEach((relation) => {
+  relations.forEach(async (relation) => {
     const { references } = relation;
     const { tableNameSingularCapitalised: singularCapitalised } =
       formatTableName(references);
-    addToPrismaModel(
+    await addToPrismaModel(
       singularCapitalised,
       `${tableNameCamelCase} ${tableNameSingularCapitalised}[]`
     );
   });
+
   const importStatement = generateImportStatement(
     "prisma",
     schema,
@@ -358,11 +359,11 @@ const generatePrismaSchema = (
   return `${importStatement}\n\n${zodSchemas}`;
 };
 
-export function generateModelContent(schema: Schema, dbType: DBType) {
+export async function generateModelContent(schema: Schema, dbType: DBType) {
   const { provider, orm, auth } = readConfigFile();
   const mappings = createOrmMappings()[orm][dbType];
   const zodSchemas = createZodSchemas(schema, orm);
-  if (schema.includeTimestamps) checkTimestampsInUtils();
+  if (schema.includeTimestamps) await checkTimestampsInUtils();
 
   if (orm === "drizzle") {
     return generateDrizzleSchema(
@@ -375,7 +376,7 @@ export function generateModelContent(schema: Schema, dbType: DBType) {
     );
   }
   if (orm === "prisma") {
-    return generatePrismaSchema(
+    return await generatePrismaSchema(
       schema,
       mappings,
       zodSchemas,

--- a/src/commands/generate/generators/model/utils.ts
+++ b/src/commands/generate/generators/model/utils.ts
@@ -142,7 +142,7 @@ export const authForWhereClausePrisma = (belongsToUser: boolean) => {
   return belongsToUser ? ", userId: session?.user.id!" : "";
 };
 
-export const updateRootSchema = (
+export const updateRootSchema = async (
   tableName: string,
   usingAuth?: boolean,
   auth?: AuthType
@@ -162,6 +162,8 @@ export const updateRootSchema = (
     case "clerk":
       break;
     case "kinde":
+      break;
+    case "supabase":
       break;
     case "lucia":
       tableNames = "keys, users, sessions";
@@ -192,10 +194,10 @@ export const updateRootSchema = (
     const afterImport = rootSchemaWithNewExport.slice(nextLineAfterLastImport);
 
     const withNewImport = `${beforeImport}${newImportStatement}${afterImport}`;
-    replaceFile(rootSchemaPath, withNewImport);
+    await replaceFile(rootSchemaPath, withNewImport);
   } else {
     // if not create schema/_root.ts -> then do same import as above
-    createFile(
+    await createFile(
       rootSchemaPath,
       `${newImportStatement}
 
@@ -216,7 +218,7 @@ import * as extended from "~/server/db/schema/_root";`
       `{ schema }`,
       `{ schema: { ...schema, ...extended } }`
     );
-    replaceFile(indexDbPath, updatedContentsFinal);
+    await replaceFile(indexDbPath, updatedContentsFinal);
 
     // update drizzle config file to add all in server/db/*
     const drizzleConfigPath = "drizzle.config.ts";
@@ -225,6 +227,6 @@ import * as extended from "~/server/db/schema/_root";`
       `schema: "./src/server/db/schema.ts",`,
       `schema: "./src/server/db/*",`
     );
-    replaceFile(drizzleConfigPath, updatedContents);
+    await replaceFile(drizzleConfigPath, updatedContents);
   }
 };

--- a/src/commands/generate/generators/model/views-shared.ts
+++ b/src/commands/generate/generators/model/views-shared.ts
@@ -3,7 +3,7 @@ import { formatFilePath } from "../../../filePaths/index.js";
 import { formatTableName } from "../../utils.js";
 import { replaceFile } from "../../../../utils.js";
 
-export const addLinkToSidebar = (tableName: string) => {
+export const addLinkToSidebar = async (tableName: string) => {
   const { tableNameKebabCase, tableNameNormalEnglishCapitalised } =
     formatTableName(tableName);
   const sidebarConfigPath = formatFilePath("config/nav.ts", {
@@ -48,5 +48,5 @@ export const addLinkToSidebar = (tableName: string) => {
 `;
     newContent = configContents.replace(searchQuery, replacement);
   }
-  replaceFile(sidebarConfigPath, newContent);
+  await replaceFile(sidebarConfigPath, newContent);
 };

--- a/src/commands/generate/generators/serverActions.ts
+++ b/src/commands/generate/generators/serverActions.ts
@@ -3,14 +3,14 @@ import { formatFilePath } from "../../filePaths/index.js";
 import { Schema } from "../types.js";
 import { formatTableName } from "../utils.js";
 
-export const scaffoldServerActions = (schema: Schema) => {
+export const scaffoldServerActions = async (schema: Schema) => {
   const { tableName } = schema;
   const { tableNameCamelCase } = formatTableName(tableName);
   const path = formatFilePath(`lib/actions/${tableNameCamelCase}.ts`, {
     prefix: "rootPath",
     removeExtension: false,
   });
-  createFile(path, generateRouteContent(schema));
+  await createFile(path, generateRouteContent(schema));
 };
 
 const generateRouteContent = (schema: Schema) => {

--- a/src/commands/generate/generators/trpcRoute.ts
+++ b/src/commands/generate/generators/trpcRoute.ts
@@ -20,9 +20,9 @@ export const scaffoldTRPCRoute = async (schema: Schema) => {
     prefix: "rootPath",
     removeExtension: false,
   })}/${tableNameCamelCase}.ts`;
-  createFile(path, generateRouteContent(schema));
+  await createFile(path, generateRouteContent(schema));
 
-  updateTRPCRouter(tableNameCamelCase);
+  await updateTRPCRouter(tableNameCamelCase);
 };
 
 // function updateTRPCRouterOld(routerName: string): void {
@@ -46,13 +46,13 @@ export const scaffoldTRPCRoute = async (schema: Schema) => {
 //   const beforeRouter = modifiedImportContent.slice(0, beforeRouterBlockEnd);
 //   const afterRouter = modifiedImportContent.slice(beforeRouterBlockEnd);
 //   const modifiedRouterContent = `${beforeRouter}\n  ${routerName}: ${routerName}Router,${afterRouter}`;
-//   replaceFile(filePath, modifiedRouterContent);
+//   await replaceFile(filePath, modifiedRouterContent);
 //
 //   consola.success(`Added ${routerName} router to root router successfully.`);
 // }
 
-export function updateTRPCRouter(routerName: string): void {
-  const { hasSrc, t3, rootPath } = readConfigFile();
+export async function updateTRPCRouter(routerName: string) {
+  const { t3, rootPath } = readConfigFile();
   const { trpcRootDir, rootRouterRelativePath } = getFileLocations();
   const filePath = rootPath.concat(`${trpcRootDir}${rootRouterRelativePath}`);
 
@@ -98,18 +98,19 @@ export function updateTRPCRouter(routerName: string): void {
       modifiedRouterContent = withNewImport.replace(oldRouter, newRouter);
     } else {
       // Regular multi-line router
-      const routerBlockEnd = withNewImport.indexOf("});");
+      const routerBlockEnd = withNewImport.indexOf("})");
       const beforeRouterBlockEnd = withNewImport.lastIndexOf(
         "\n",
         routerBlockEnd
       );
       const beforeRouter = withNewImport.slice(0, beforeRouterBlockEnd);
+      const hasCommaBefore = beforeRouter.endsWith(",");
       const afterRouter = withNewImport.slice(beforeRouterBlockEnd);
       const newRouterStatement = `\n  ${routerName}: ${routerName}Router,`;
-      modifiedRouterContent = `${beforeRouter}${newRouterStatement}${afterRouter}`;
+      modifiedRouterContent = `${beforeRouter}${hasCommaBefore ? "" : ","}${newRouterStatement}${afterRouter}`;
     }
 
-    replaceFile(filePath, modifiedRouterContent);
+    await replaceFile(filePath, modifiedRouterContent);
 
     // consola.success(
     //   `Added '${routerName}' router to the root tRPC router successfully.`

--- a/src/commands/generate/generators/views-with-server-actions.ts
+++ b/src/commands/generate/generators/views-with-server-actions.ts
@@ -51,19 +51,19 @@ export const scaffoldViewsAndComponentsWithServerActions = async (
   // require trpc for these views
   if (packages.includes("shadcn-ui")) {
     // check if utils correct
-    checkUtils();
+    await checkUtils();
 
     // check if modal exists components/shared/Modal.tsx
-    checkModalExists();
+    await checkModalExists();
 
     // check if modal exists components/shared/BackButton.tsx
-    checkBackButtonExists();
+    await checkBackButtonExists();
 
     // check if vfh exists
-    checkValidatedForm();
+    await checkValidatedForm();
 
     // create view - tableName/page.tsx
-    createFile(
+    await createFile(
       formatFilePath(`app/(app)/${tableNameKebabCase}/page.tsx`, {
         prefix: "rootPath",
         removeExtension: false,
@@ -72,7 +72,7 @@ export const scaffoldViewsAndComponentsWithServerActions = async (
     );
 
     // create components/tableName/TableNameList.tsx
-    createFile(
+    await createFile(
       formatFilePath(
         `components/${tableNameCamelCase}/${tableNameSingularCapitalised}List.tsx`,
         { removeExtension: false, prefix: "rootPath" }
@@ -81,7 +81,7 @@ export const scaffoldViewsAndComponentsWithServerActions = async (
     );
 
     // create components/tableName/TableNameForm.tsx
-    createFile(
+    await createFile(
       formatFilePath(
         `components/${tableNameCamelCase}/${tableNameSingularCapitalised}Form.tsx`,
         { prefix: "rootPath", removeExtension: false }
@@ -90,7 +90,7 @@ export const scaffoldViewsAndComponentsWithServerActions = async (
     );
 
     // create optimisticEntity
-    createFile(
+    await createFile(
       formatFilePath(
         `app/(app)/${tableNameKebabCase}/useOptimistic${tableNameCapitalised}.tsx`,
         {
@@ -102,7 +102,7 @@ export const scaffoldViewsAndComponentsWithServerActions = async (
     );
 
     // create tableName/[id]/page.tsx
-    createFile(
+    await createFile(
       formatFilePath(
         `app/(app)/${tableNameKebabCase}/[${tableNameSingular}Id]/page.tsx`,
         { removeExtension: false, prefix: "rootPath" }
@@ -118,7 +118,7 @@ export const scaffoldViewsAndComponentsWithServerActions = async (
           return `${parent.tableNameKebabCase}/[${parent.tableNameSingular}Id]/`;
         })
         .join("");
-      createFile(
+      await createFile(
         formatFilePath(
           `app/(app)/${baseUrl}${tableNameKebabCase}/[${tableNameSingular}Id]/page.tsx`,
           { removeExtension: false, prefix: "rootPath" }
@@ -127,7 +127,7 @@ export const scaffoldViewsAndComponentsWithServerActions = async (
       );
     }
     // create tableName/[id]/OptimisticEntity.tsx
-    createFile(
+    await createFile(
       formatFilePath(
         `app/(app)/${tableNameKebabCase}/[${tableNameSingular}Id]/Optimistic${tableNameSingularCapitalised}.tsx`,
         { removeExtension: false, prefix: "rootPath" }
@@ -157,7 +157,7 @@ export const scaffoldViewsAndComponentsWithServerActions = async (
     // await installShadcnUIComponents(baseComponents);
     addToShadcnComponentList(baseComponents);
   } else {
-    addPackage();
+    await addPackage();
   }
 };
 
@@ -1068,7 +1068,7 @@ const SaveButton = ({
 `;
 };
 
-const checkUtils = () => {
+const checkUtils = async () => {
   const utilTsPath = formatFilePath("lib/utils.ts", {
     removeExtension: false,
     prefix: "rootPath",
@@ -1085,15 +1085,13 @@ export type OptimisticAction<T> = {
   data: T;
 };
 `;
-  if (utilTsContent.includes(contentToQuery)) {
-    return;
-  } else {
-    const newUtilTs = utilTsContent.concat("\n\n".concat(contentToQuery));
-    replaceFile(utilTsPath, newUtilTs);
-  }
+  if (utilTsContent.includes(contentToQuery)) return;
+
+  const newUtilTs = utilTsContent.concat("\n\n".concat(contentToQuery));
+  await replaceFile(utilTsPath, newUtilTs);
 };
 
-const checkModalExists = () => {
+const checkModalExists = async () => {
   const modalPath = formatFilePath("components/shared/Modal.tsx", {
     removeExtension: false,
     prefix: "rootPath",
@@ -1134,11 +1132,11 @@ export default function Modal({
   );
 }
 `;
-    createFile(modalPath, modalContents);
+    await createFile(modalPath, modalContents);
   }
 };
 
-const checkBackButtonExists = () => {
+const checkBackButtonExists = async () => {
   const bbPath = formatFilePath("components/shared/BackButton.tsx", {
     removeExtension: false,
     prefix: "rootPath",
@@ -1184,7 +1182,7 @@ export function BackButton({
   );
 }
 `;
-    createFile(bbPath, bbContents);
+    await createFile(bbPath, bbContents);
   }
 };
 
@@ -1309,7 +1307,7 @@ export const useOptimistic${tableNamePluralCapitalised} = (
 `;
 };
 
-const checkValidatedForm = () => {
+const checkValidatedForm = async () => {
   const vfhPath = formatFilePath("lib/hooks/useValidatedForm.tsx", {
     prefix: "rootPath",
     removeExtension: false,
@@ -1356,8 +1354,9 @@ export function useValidatedForm<Entity>(insertEntityZodSchema: ZodSchema) {
 `;
 
   const vfhExists = existsSync(vfhPath);
+
   if (!vfhExists) {
-    createFile(vfhPath, vfhContent);
+    await createFile(vfhPath, vfhContent);
   }
 };
 

--- a/src/commands/generate/generators/views.ts
+++ b/src/commands/generate/generators/views.ts
@@ -1,11 +1,6 @@
 import { DBField } from "../../../types.js";
 import pluralize from "pluralize";
-import {
-  createFile,
-  getFileContents,
-  installShadcnUIComponents,
-  readConfigFile,
-} from "../../../utils.js";
+import { createFile, getFileContents, readConfigFile } from "../../../utils.js";
 import { addPackage } from "../../add/index.js";
 import { formatFilePath, getFilePaths } from "../../filePaths/index.js";
 import { Schema } from "../types.js";
@@ -28,26 +23,26 @@ export const scaffoldViewsAndComponents = async (schema: Schema) => {
   if (packages.includes("trpc") && packages.includes("shadcn-ui")) {
     // create view - tableName/page.tsx
     const rootPath = hasSrc ? "src/" : "";
-    createFile(
+    await createFile(
       rootPath.concat(`app/(app)/${tableNameKebabCase}/page.tsx`),
       generateView(schema)
     );
     // create components/tableName/TableNameList.tsx
-    createFile(
+    await createFile(
       rootPath.concat(
         `components/${tableNameCamelCase}/${tableNameSingularCapitalised}List.tsx`
       ),
       createListComponent(schema)
     );
     // create components/tableName/TableNameForm.tsx
-    createFile(
+    await createFile(
       rootPath.concat(
         `components/${tableNameCamelCase}/${tableNameSingularCapitalised}Form.tsx`
       ),
       createFormComponent(schema)
     );
     // create components/tableName/TableNameModal.tsx
-    createFile(
+    await createFile(
       rootPath.concat(
         `components/${tableNameCamelCase}/${tableNameSingularCapitalised}Modal.tsx`
       ),

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -325,7 +325,7 @@ async function askForChildModel(parentModel: string) {
   });
 }
 
-export function preBuild() {
+export async function preBuild() {
   const config = readConfigFile();
 
   if (!config) {
@@ -334,7 +334,7 @@ export function preBuild() {
     return false;
   }
 
-  if (config.orm === undefined) updateConfigFileAfterUpdate();
+  if (config.orm === undefined) await updateConfigFileAfterUpdate();
   return true;
 }
 
@@ -449,23 +449,24 @@ async function generateResources(
       message: `Would you like to add a link to '${tnEnglish}' in your sidebar?`,
       default: true,
     });
-    if (addToSidebar) addLinkToSidebar(schema.tableName);
+    if (addToSidebar) await addLinkToSidebar(schema.tableName);
   }
 
   if (resourceType.includes("model"))
     scaffoldModel(schema, config.driver, config.hasSrc);
-  if (resourceType.includes("api_route")) scaffoldAPIRoute(schema);
-  if (resourceType.includes("trpc_route")) scaffoldTRPCRoute(schema);
+  if (resourceType.includes("api_route")) await scaffoldAPIRoute(schema);
+  if (resourceType.includes("trpc_route")) await scaffoldTRPCRoute(schema);
   if (resourceType.includes("views_and_components_trpc"))
-    scaffoldViewsAndComponents(schema);
-  if (resourceType.includes("server_actions")) scaffoldServerActions(schema);
+    await scaffoldViewsAndComponents(schema);
+  if (resourceType.includes("server_actions"))
+    await scaffoldServerActions(schema);
   if (resourceType.includes("views_and_components_server_actions"))
-    scaffoldViewsAndComponentsWithServerActions(schema);
+    await scaffoldViewsAndComponentsWithServerActions(schema);
   await installShadcnComponentList();
 }
 
 export async function buildSchema() {
-  const ready = preBuild();
+  const ready = await preBuild();
   if (!ready) return;
 
   const config = readConfigFile();

--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -327,7 +327,7 @@ export function getCurrentSchemas() {
   }
 }
 
-export const addToPrismaSchema = (schema: string, modelName: string) => {
+export const addToPrismaSchema = async (schema: string, modelName: string) => {
   const schemaPath = "prisma/schema.prisma";
   const schemaExists = existsSync(schemaPath);
   if (schemaExists) {
@@ -343,11 +343,11 @@ export const addToPrismaSchema = (schema: string, modelName: string) => {
         schemaContents.slice(0, modelStart) +
         schema +
         schemaContents.slice(modelEnd + 1);
-      replaceFile(schemaPath, newContent);
+      await replaceFile(schemaPath, newContent);
       // consola.success(`Replaced ${modelName} in Prisma schema`);
     } else {
       const newContent = schemaContents.concat("\n", schema);
-      replaceFile(schemaPath, newContent);
+      await replaceFile(schemaPath, newContent);
       // consola.success(`Added ${modelName} to Prisma schema`);
     }
   } else {
@@ -382,7 +382,10 @@ const getPrismaModelStartAndEnd = (schema: string, modelName: string) => {
   return { modelStart, modelEnd, modelExists };
 };
 
-export function addToPrismaModel(modelName: string, attributesToAdd: string) {
+export async function addToPrismaModel(
+  modelName: string,
+  attributesToAdd: string
+) {
   const hasSchema = existsSync("prisma/schema.prisma");
   if (!hasSchema) {
     console.error("Prisma schema not found!");
@@ -401,12 +404,12 @@ export function addToPrismaModel(modelName: string, attributesToAdd: string) {
 
     const newSchema =
       beforeModelEnd + "  " + attributesToAdd + "\n" + afterModelEnd;
-    replaceFile("prisma/schema.prisma", newSchema);
+    await replaceFile("prisma/schema.prisma", newSchema);
     consola.info("Updated Prisma schema");
   }
 }
 
-export function addToPrismaModelBulk(
+export async function addToPrismaModelBulk(
   modelName: string,
   attributesToAdd: string
 ) {
@@ -425,7 +428,7 @@ export function addToPrismaModelBulk(
 
     const newSchema =
       beforeModelEnd + "  " + attributesToAdd + "\n" + afterModelEnd;
-    replaceFile("prisma/schema.prisma", newSchema);
+    await replaceFile("prisma/schema.prisma", newSchema);
     consola.info("Updated Prisma schema");
   }
 }

--- a/src/commands/init/index.ts
+++ b/src/commands/init/index.ts
@@ -5,7 +5,11 @@ import { consola } from "consola";
 import { addPackage } from "../add/index.js";
 import { existsSync, readFileSync } from "fs";
 import path from "path";
-import { checkForPackageManager } from "./utils.js";
+import {
+  // checkAndCreatIfNotExistPrettierConfig,
+  checkForPackageManager,
+  createPrettierConfigFileIfNotExist,
+} from "./utils.js";
 import figlet from "figlet";
 import chalk from "chalk";
 
@@ -64,7 +68,9 @@ export async function initProject(options?: InitOptions) {
   if (tsConfigString.includes("@/*")) alias = "@";
   if (tsConfigString.includes("~/*")) alias = "~";
 
-  createConfigFile({
+  await createPrettierConfigFileIfNotExist();
+
+  await createConfigFile({
     driver: undefined,
     hasSrc: srcExists,
     provider: undefined,

--- a/src/commands/init/utils.ts
+++ b/src/commands/init/utils.ts
@@ -11,7 +11,12 @@ import {
   DBType,
   PMType,
 } from "../../types.js";
-import { createFile, replaceFile, updateConfigFile } from "../../utils.js";
+import {
+  createFile,
+  readConfigFile,
+  replaceFile,
+  updateConfigFile,
+} from "../../utils.js";
 import { consola } from "consola";
 import { updateTsConfigPrismaTypeAlias } from "../add/orm/utils.js";
 import { addToInstallList } from "../add/utils.js";
@@ -331,4 +336,3 @@ export const toggleAnalytics = (input: { toggle?: boolean }) => {
     );
   }
 };
-

--- a/src/commands/init/utils.ts
+++ b/src/commands/init/utils.ts
@@ -1,4 +1,8 @@
-import { existsSync, readFileSync } from "fs";
+import {
+  existsSync,
+  readFileSync,
+  // writeFileSync
+} from "fs";
 import {
   AvailablePackage,
   Config,
@@ -7,18 +11,16 @@ import {
   DBType,
   PMType,
 } from "../../types.js";
-import {
-  installPackages,
-  readConfigFile,
-  replaceFile,
-  updateConfigFile,
-  wrapInParenthesis,
-} from "../../utils.js";
+import { createFile, replaceFile, updateConfigFile } from "../../utils.js";
 import { consola } from "consola";
 import { updateTsConfigPrismaTypeAlias } from "../add/orm/utils.js";
 import { addToInstallList } from "../add/utils.js";
 import { addNanoidToUtils } from "../add/orm/drizzle/utils.js";
-// test
+import {
+  format as prettierFormat,
+  resolveConfigFile,
+  resolveConfig as resolvePrettierConfig,
+} from "prettier";
 
 export const DBProviders: DBProviderOptions = {
   pg: [
@@ -47,7 +49,7 @@ export const DBProviders: DBProviderOptions = {
 export const checkForExistingPackages = async (rootPath: string) => {
   consola.start("Checking project for existing packages...");
   // get package json
-  const { preferredPackageManager } = readConfigFile();
+  // const { preferredPackageManager } = readConfigFile();
   const packageJsonInitText = readFileSync("package.json", "utf-8");
 
   let configObj: Partial<Config> = {
@@ -58,6 +60,7 @@ export const checkForExistingPackages = async (rootPath: string) => {
     trpc: ["@trpc/client", "@trpc/react-query", "@trpc/server", "@trpc/next"],
     clerk: ["@clerk/nextjs"],
     lucia: ["lucia"],
+    supabase: ["@supabase/supabase-js", "@supabase/ssr"],
     prisma: ["prisma"],
     resend: ["resend"],
     stripe: ["stripe", "@stripe/stripe-js"],
@@ -74,6 +77,7 @@ export const checkForExistingPackages = async (rootPath: string) => {
     clerk: "auth",
     "next-auth": "auth",
     lucia: "auth",
+    supabase: "auth",
     drizzle: "orm",
   };
 
@@ -198,7 +202,7 @@ export const checkForExistingPackages = async (rootPath: string) => {
       //   { regular: "", dev: "zod-prisma" },
       //   preferredPackageManager,
       // );
-      addZodGeneratorToPrismaSchema();
+      await addZodGeneratorToPrismaSchema();
       // consola.success("Successfully installed!");
 
       await updateTsConfigPrismaTypeAlias();
@@ -211,17 +215,17 @@ export const checkForExistingPackages = async (rootPath: string) => {
       //   preferredPackageManager
       // );
       addToInstallList({ regular: ["drizzle-zod", "nanoid"], dev: [] });
-      addNanoidToUtils();
+      await addNanoidToUtils();
       // consola.success("Successfully installed!");
     }
   }
   // if (drizzle), check if using one schema file or schema directory - perhaps just force users?
 
   // update config file
-  updateConfigFile(configObj);
+  await updateConfigFile(configObj);
 };
 
-const addZodGeneratorToPrismaSchema = () => {
+const addZodGeneratorToPrismaSchema = async () => {
   const hasSchema = existsSync("prisma/schema.prisma");
   if (!hasSchema) {
     console.error("Prisma schema not found!");
@@ -240,7 +244,7 @@ generator zod {
 }
 `);
 
-  replaceFile("prisma/schema.prisma", newSchema);
+  await replaceFile("prisma/schema.prisma", newSchema);
   consola.info("Updated Prisma schema");
 };
 
@@ -254,4 +258,62 @@ export const checkForPackageManager = (): PMType | null => {
   if (yarn) return "yarn";
 
   return null;
+};
+
+export const createPrettierConfigFileIfNotExist = async () => {
+  const userPrettierConfigPath = await resolveConfigFile();
+
+  // Throws an error if there is an error during parsing the users prettier config file
+  let prettierConfig = await resolvePrettierConfig(userPrettierConfigPath);
+
+  if (prettierConfig != null)
+    consola.success(
+      "Prettier config found! Using prettier config for formatting..."
+    );
+
+  if (prettierConfig === null) {
+    consola.info(
+      "Prettier config not found! Create default prettier config for further usage..."
+    );
+
+    await createDefaultPrettierConfig();
+  }
+};
+
+export const formatFileContentWithPrettier = async (
+  content: string,
+  filePath: string,
+  skipPrettier?: boolean
+) => {
+  if (skipPrettier) return content;
+
+  const prettierConfigPath = await resolveConfigFile();
+
+  // Throws an error if there is an error during parsing the users prettier config file
+  let prettierConfig = await resolvePrettierConfig(prettierConfigPath);
+
+  if (
+    prettierConfig &&
+    typeof prettierConfig === "object" &&
+    !prettierConfig.filepath
+  )
+    prettierConfig.filepath = filePath;
+
+  return await prettierFormat(content, prettierConfig);
+};
+
+const createDefaultPrettierConfig = async () => {
+  /** @link https://prettier.io/docs/en/configuration#basic-configuration */
+  const defaultPrettierConfig = {
+    trailingComma: "es5" as const,
+    tabWidth: 4,
+    semi: false,
+    singleQuote: true,
+  };
+
+  await createFile(
+    ".prettierrc",
+    JSON.stringify(defaultPrettierConfig, null, 2),
+    true
+  );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,10 +6,10 @@ import { buildSchema } from "./commands/generate/index.js";
 import { addPackage } from "./commands/add/index.js";
 
 const program = new Command();
-program.name("kirimase").description("Kirimase CLI").version("0.0.53");
+program.name("kirimase").description("Kirimase CLI").version("0.0.54");
 
 addCommonOptions(program.command("init"))
-  .description("initialise and configure kirimase within directory")
+  .description("initialise and configure kirimase within a directory")
   .action(initProject);
 
 program
@@ -37,7 +37,10 @@ function addCommonOptions(command: Command) {
     .option("-o, --orm <orm>", "preferred orm (prisma, drizzle)")
     .option("-db, --db <db>", "preferred database (pg, mysql, sqlite)")
     .option("-dbp, --db-provider <db>", "database provider")
-    .option("-a, --auth <auth>", "preferred auth (next-auth, clerk, lucia)")
+    .option(
+      "-a, --auth <auth>",
+      "preferred auth (next-auth, clerk, lucia, supabase)"
+    )
     .option(
       "-ap, --auth-providers <auth-providers...>",
       "auth providers (if using next-auth - discord, google, github, apple)"

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -74,12 +74,13 @@ export type AvailablePackage =
   | "resend"
   | "lucia"
   | "kinde"
-  | "stripe";
+  | "stripe"
+  | "supabase";
 
 export type PackageType = "orm" | "auth" | "componentLib" | "misc";
 export type ComponentLibType = "shadcn-ui";
 export type ORMType = "drizzle" | "prisma";
-export type AuthType = "next-auth" | "clerk" | "lucia" | "kinde";
+export type AuthType = "next-auth" | "clerk" | "lucia" | "kinde" | "supabase";
 export type MiscType = "trpc" | "stripe" | "resend";
 export type AuthSubType = "self-hosted" | "managed";
 


### PR DESCRIPTION
This PR adds 2 things:

1. [Supabase](https://supabase.com/) as a new Auth Provider 
2. Either reads the users prettier config file or generates a default prettier config file and also formats the generated files based on the prettier config.

I had to convert many functions to async ones but it still works as far as I tested ( add and generate command still work ).

Would close this issue: #49.

Btw to get RLS with Supabase and Drizzle generally I think we have to use auth.uid()::text in the RLS editor. It worked like that then but not without.

Result: 
![kirimase_supabase_marked](https://github.com/nicoalbanese/kirimase/assets/51196565/bf4df544-8d96-44c7-b4b4-5802ecda244a)