### PR TITLE
fix issues with drizzle-planetscale integration

### DIFF
--- a/src/commands/add/orm/drizzle/generators.ts
+++ b/src/commands/add/orm/drizzle/generators.ts
@@ -165,15 +165,17 @@ export const db = drizzle(rdsClient, {
       break;
     case "planetscale":
       indexTS = `import { drizzle } from "drizzle-orm/planetscale-serverless";
-import { connect } from "@planetscale/database";
+import { Client } from "@planetscale/database";
 import { env } from "${formatFilePath(envMjs, {
         removeExtension: false,
         prefix: "alias",
       })}";
  
 // create the connection
-export const connection = connect({
-  url: env.DATABASE_URL
+export const connection = new Client({
+  host: env.DATABASE_HOST,
+  username: env.DATABASE_USERNAME,
+  password: env.DATABASE_PASSWORD,
 });
  
 export const db = drizzle(connection);
@@ -608,7 +610,6 @@ export const createDotEnv = (
   orm: ORMType,
   preferredPackageManager: PMType,
   databaseUrl?: string,
-  usingPlanetscale: boolean = false,
   rootPathOld: string = ""
 ) => {
   const {
@@ -624,11 +625,7 @@ export const createDotEnv = (
   if (!envExists)
     createFile(
       ".env",
-      `${
-        orm === "drizzle" && usingPlanetscale
-          ? `# When using the PlanetScale driver with Drizzle, your connection string must end with ?ssl={"rejectUnauthorized":true} instead of ?sslaccept=strict.\n`
-          : ""
-      }DATABASE_URL=${dburl}`
+      `DATABASE_URL=${dburl}`
     );
 
   const envmjsfilePath = formatFilePath(envMjs, {

--- a/src/commands/add/orm/drizzle/index.ts
+++ b/src/commands/add/orm/drizzle/index.ts
@@ -66,9 +66,17 @@ export const addDrizzle = async (
     "drizzle",
     preferredPackageManager,
     databaseUrl,
-    dbProvider === "planetscale",
     hasSrc ? "src/" : ""
   );
+  if (dbProvider === "planetscale")
+    addToDotEnv(
+      [
+        { key: "DATABASE_HOST", value: "" },
+        { key: "DATABASE_USERNAME", value: "" },
+        { key: "DATABASE_PASSWORD", value : "" },
+      ],
+      rootPath
+    );
   if (dbProvider === "vercel-pg")
     addToDotEnv(
       [

--- a/src/commands/add/orm/prisma/index.ts
+++ b/src/commands/add/orm/prisma/index.ts
@@ -48,7 +48,6 @@ export const addPrisma = async (
       "prisma",
       preferredPackageManager,
       generateDbUrl(dbType),
-      true,
       hasSrc ? "src/" : ""
     );
   } else {
@@ -58,7 +57,6 @@ export const addPrisma = async (
       "prisma",
       preferredPackageManager,
       generateDbUrl(dbType),
-      false,
       hasSrc ? "src/" : ""
     );
   }


### PR DESCRIPTION
fixes #158 

drizzle is now enforcing the use of the Client instance to handle connections to PlanetScale
instead of using connect.

link [here](https://orm.drizzle.team/docs/get-started-mysql#planetscale)