### PR TITLE
Add generate option to load schemas from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,16 @@ Kirimase generates:
 - Scaffolds views using Shadcn-UI to enable immediate CRUD operations (including select fields for adding relations and datepickers for dates).
 - Option to use either React Hook Form with tRPC or plain React (useOptimistic and useValidated Form hooks)
 
+### Generate schemas from JSON file
+
+You can also import and generate schemas from a JSON file via the command
+
+```sh
+kirimase generate -f <path-to-schema.json>
+```
+
+More info [here](commands/generate/generate-schema-from-file.md)
+
 ## Run in non-interactive mode
 
 As of v0.0.23, you can run `kirimase init` and `kirimase add` entirely via the command line as follows:

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "figlet": "^1.7.0",
     "ora": "^8.0.1",
     "pluralize": "^8.0.0",
-    "strip-json-comments": "^5.0.1"
+    "strip-json-comments": "^5.0.1",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/node": "^20.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ dependencies:
   strip-json-comments:
     specifier: ^5.0.1
     version: 5.0.1
+  zod:
+    specifier: ^3.22.4
+    version: 3.22.4
 
 devDependencies:
   '@types/node':
@@ -1398,3 +1401,7 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
     dev: true
+
+  /zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+    dev: false

--- a/src/commands/generate/generate-schema-from-file.md
+++ b/src/commands/generate/generate-schema-from-file.md
@@ -1,0 +1,76 @@
+## Generating schemas from JSON file
+
+You can also import and generate schemas from a JSON file via the command
+
+```sh
+kirimase generate -f <path-to-schema.json>
+```
+
+### Input format
+
+You must provide an array of schema, and each of them must follows the `Schema` type definition
+
+```typescript
+type Schema = {
+  tableName: string;
+  fields: {
+    name: string;
+    type: T;
+    references?: string;
+    notNull?: boolean;
+    cascade?: boolean;
+  };
+  index: string;
+  belongsToUser?: boolean;
+  includeTimestamps: boolean;
+  children?: Schema[];
+};
+```
+
+As you can guess, providing more than one schema will make Kirimase generates multiple schemas in a single `generate` command
+
+### Examples
+
+Here's a sample of a valid `schema.json`
+
+```json
+[
+  {
+    "tableName": "menu",
+    "fields": [
+      { "name": "name", "type": "varchar", "notNull": true },
+      { "name": "price", "type": "number", "notNull": true }
+    ],
+    "index": "name",
+    "belongsToUser": false,
+    "includeTimestamps": true,
+    "children": []
+  }
+]
+```
+
+Another example with children
+
+```json
+[
+  {
+    "tableName": "menu_discount",
+    "fields": [
+      { "name": "code", "type": "number", "notNull": true }
+    ],
+    "index": null,
+    "belongsToUser": false,
+    "includeTimestamps": false,
+    "children": [
+      {
+        "tableName": "menu_discount_analytics",
+        "fields": [{ "name": "used_count", "type": "number", "notNull": true }],
+        "index": null,
+        "belongsToUser": false,
+        "includeTimestamps": false,
+        "children": []
+      }
+    ]
+  }
+]
+```

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -556,7 +556,7 @@ export async function buildSchema(options: GenerateOptions) {
     for (let schema of formattedSchemas) {
       await generateResources(schema, resourceType);
     }
-    printGenerateNextSteps(schema, resourceType);
+    printGenerateNextSteps(schemas, resourceType);
   } else {
     consola.warn(
       "You need to have an ORM installed in order to use the scaffold command."

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -6,6 +6,7 @@ import {
   DBField,
   DBType,
   DrizzleColumnType,
+  GenerateOptions,
   ORMType,
   PrismaColumnType,
 } from "../../types.js";
@@ -175,8 +176,8 @@ async function askForResourceType() {
           disabled: !packages.includes("trpc")
             ? "[You need to have tRPC installed. Run 'kirimase add']"
             : viewRequested === "views_and_components_trpc"
-              ? "[Already generated with your selected view]"
-              : false,
+            ? "[Already generated with your selected view]"
+            : false,
         },
       ].filter((item) =>
         viewRequested ? !viewRequested.includes(item.value.split("_")[0]) : item
@@ -495,7 +496,7 @@ async function generateResources(
   await installShadcnComponentList();
 }
 
-export async function buildSchema() {
+export async function buildSchema(options: GenerateOptions) {
   const ready = preBuild();
   if (!ready) return;
 

--- a/src/commands/generate/utils.ts
+++ b/src/commands/generate/utils.ts
@@ -448,12 +448,20 @@ const resourceMapping: Record<TResource, string> = {
 };
 
 export const printGenerateNextSteps = (
-  schema: Schema,
+  schemas: Schema[],
   resources: TResource[]
 ) => {
   const config = readConfigFile();
-  const { tableNameNormalEnglishSingular, tableNameKebabCase } =
-    formatTableName(schema.tableName);
+  const { resourceNames, resourceEndpoints } = schemas.reduce(
+    (acc, schema) => {
+      const { tableNameNormalEnglishSingular, tableNameKebabCase } =
+        formatTableName(schema.tableName);
+      acc.resourceNames.push(tableNameNormalEnglishSingular);
+      acc.resourceEndpoints.push(tableNameKebabCase);
+      return acc;
+    },
+    { resourceNames: [], resourceEndpoints: [] }
+  );
 
   const ppm = config?.preferredPackageManager ?? "npm";
   const dbMigration = [
@@ -463,7 +471,9 @@ export const printGenerateNextSteps = (
 
   const viewInBrowser = [
     `Run \`${ppm} run dev\``,
-    `Open http://localhost:3000/${tableNameKebabCase} in your browser`,
+    `Open the following URLs in your browser:\n${resourceEndpoints
+      .map((endpoint) => `👉 http://localhost:3000/${endpoint}`)
+      .join("\n")}`,
   ];
 
   const nextStepsList = [
@@ -476,7 +486,7 @@ export const printGenerateNextSteps = (
 
   consola.box(`🎉 Success! 
 
-Kirimase generated the following resources for \`${tableNameNormalEnglishSingular}\`:
+Kirimase generated the following resources for \`${resourceNames.join(",")}\`:
 ${resources.map((r) => `- ${resourceMapping[r]}`).join("\n")}
 
 ${createNextStepsList(nextStepsList)}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ addCommonOptions(program.command("init"))
 program
   .command("generate")
   .description("Generate a new resource")
+  .option("-f, --from-file <value>", "load schema from a JSON file")
   .action(buildSchema);
 
 addCommonOptions(program.command("add"))

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -118,6 +118,10 @@ export type InitOptions = {
   includeExample?: boolean;
 };
 
+export type GenerateOptions = {
+  fromFile?: string | null;
+};
+
 // export type BuildOptions = {
 //   resources?: ("model" | "api_route" | "trpc_route" | "views_and_components")[];
 //   table?: string;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,10 @@
 import { AuthProvider } from "./commands/add/auth/next-auth/utils.ts";
+import {
+  pgColumns,
+  mysqlColumns,
+  sqliteColumns,
+  prismaColumns,
+} from "./utils.ts";
 
 export type DBType = "pg" | "mysql" | "sqlite";
 export type DBProviderItem = {
@@ -127,48 +133,10 @@ export type ScaffoldSchema = {
   index?: string;
 };
 
-export type pgColumnType =
-  | "varchar"
-  | "text"
-  | "number"
-  | "float"
-  | "boolean"
-  | "references"
-  | "timestamp"
-  | "date";
-// | "json";
-
-export type mysqlColumnType =
-  | "varchar"
-  | "text"
-  | "number"
-  | "float"
-  | "boolean"
-  | "references"
-  | "date"
-  | "timestamp";
-// | "json";
-
-export type sqliteColumnType =
-  | "string"
-  | "number"
-  | "boolean"
-  | "date"
-  | "timestamp"
-  | "references";
-// | "blob";
-
-export type PrismaColumnType =
-  | "String"
-  | "Boolean"
-  | "Int"
-  | "BigInt"
-  | "Float"
-  | "Decimal"
-  | "Boolean"
-  | "DateTime"
-  | "References";
-// | "Json";
+export type pgColumnType = (typeof pgColumns)[number];
+export type mysqlColumnType = (typeof mysqlColumns)[number];
+export type sqliteColumnType = (typeof sqliteColumns)[number];
+export type PrismaColumnType = (typeof prismaColumns)[number];
 
 export type DotEnvItem = {
   key: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -269,3 +269,50 @@ export const sendEvent = async (
     return;
   }
 };
+
+export const pgColumns = [
+  "varchar",
+  "text",
+  "number",
+  "float",
+  "boolean",
+  "references",
+  "timestamp",
+  "date",
+  // "json",
+] as const;
+
+export const mysqlColumns = [
+  "varchar",
+  "text",
+  "number",
+  "float",
+  "boolean",
+  "references",
+  "date",
+  "timestamp",
+  // "json",
+] as const;
+
+export const sqliteColumns = [
+  "string",
+  "number",
+  "boolean",
+  "date",
+  "timestamp",
+  "references",
+  // "blob",
+] as const;
+
+export const prismaColumns = [
+  "String",
+  "Boolean",
+  "Int",
+  "BigInt",
+  "Float",
+  "Decimal",
+  "Boolean",
+  "DateTime",
+  "References",
+  // "Json",
+] as const;


### PR DESCRIPTION
## Background

This PR will allow users to load schemas from a JSON file when running `generate` command, hence skipping the manual data entry. This will make it easy to move from one project to another that has shared schemas

Sample usage
```sh
kirimase generate -f <path-to-schema.json>
```

### Input example

Here's a sample of a valid `schema.json` (basically the shape of `Schema`)
```json
[
  {
    "tableName": "menu",
    "fields": [
      { "name": "name", "type": "varchar", "notNull": true },
      { "name": "price", "type": "number", "notNull": true }
    ],
    "index": "name",
    "belongsToUser": false,
    "includeTimestamps": true,
    "children": []
  }
]
```

### Validation

This PR also comes with the necessary validation such as requiring the table name to be snakeCase. The validation is done by Zod. If errors are present in the schema, Kirimase will stop the execution and log the errors appropriately, such as

```sh
[
  {
    "message": "Field name must be in snake_case if more than one word.",
    "field": "fields.0.name",
    "tableName": "menu.menu_discount.menu_discount_analytics"
  },
  {
    "message": "Table name must be in snake_case if more than one word, and plural.",
    "field": "tableName",
    "tableName": "menu.menuReview"
  }
]
```

## Note on using Zod

Since strict mode is not enabled in this project, we will not be able to fully utilize Zod, such as type inferring