### PR TITLE
Adds the globe icon to /account route in nav.ts

### DIFF
--- a/src/commands/add/misc/navbar/generators.ts
+++ b/src/commands/add/misc/navbar/generators.ts
@@ -189,7 +189,7 @@ type AdditionalLinks = {
 export const defaultLinks: SidebarLink[] = [
   { href: "/dashboard", title: "Home", icon: HomeIcon },${
     auth !== null
-      ? `\n  { href: "/account", title: "Account", icon: Cog },`
+      ? `\n  { href: "/account", title: "Account", icon: Globe },`
       : ""
   }${
     componentLib === "shadcn-ui"


### PR DESCRIPTION
Small PR:
`Cog` Icon was being used for both `/settings` and `/account`

<!-- insert PR description above -->
-----
<a href="https://stackblitz.com/~/github.com/ADRlANO/kirimase/tree/ADRlANO/patch-39410"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/ADRlANO/kirimase/tree/ADRlANO/patch-39410)._