### PR TITLE
Update Prisma mutations to use `updateMany` and `deleteMany`

### DIFF
--- a/src/commands/generate/generators/model/mutations/generators.ts
+++ b/src/commands/generate/generators/model/mutations/generators.ts
@@ -241,7 +241,9 @@ const generatePrismaUpdateMutation = (schema: Schema) => {
       : `${tableNameSingular}`
   });
   try {
-    const ${tableNameFirstChar} = await db.${tableNameSingular}.updateMany({ where: { id: ${tableNameSingular}Id${authForWhereClausePrisma(
+    const ${tableNameFirstChar} = await db.${tableNameSingular}.${
+      belongsToUser ? "updateMany" : "update"
+    }({ where: { id: ${tableNameSingular}Id${authForWhereClausePrisma(
       belongsToUser
     )} }, data: new${tableNameSingularCapitalised}})
     return { ${tableNameSingular}: ${tableNameFirstChar} };
@@ -264,7 +266,9 @@ const generatePrismaDeleteMutation = (schema: Schema) => {
   return `export const delete${tableNameSingularCapitalised} = async (id: ${tableNameSingularCapitalised}Id) => {${getAuth}
   const { id: ${tableNameSingular}Id } = ${tableNameSingular}IdSchema.parse({ id });
   try {
-    const ${tableNameFirstChar} = await db.${tableNameSingular}.deleteMany({ where: { id: ${tableNameSingular}Id${authForWhereClausePrisma(
+    const ${tableNameFirstChar} = await db.${tableNameSingular}.${
+    belongsToUser ? "deleteMany" : "delete"
+    }({ where: { id: ${tableNameSingular}Id${authForWhereClausePrisma(
       belongsToUser
     )} }})
     return { ${tableNameSingular}: ${tableNameFirstChar} };

--- a/src/commands/generate/generators/model/mutations/generators.ts
+++ b/src/commands/generate/generators/model/mutations/generators.ts
@@ -241,7 +241,7 @@ const generatePrismaUpdateMutation = (schema: Schema) => {
       : `${tableNameSingular}`
   });
   try {
-    const ${tableNameFirstChar} = await db.${tableNameSingular}.update({ where: { id: ${tableNameSingular}Id${authForWhereClausePrisma(
+    const ${tableNameFirstChar} = await db.${tableNameSingular}.updateMany({ where: { id: ${tableNameSingular}Id${authForWhereClausePrisma(
       belongsToUser
     )} }, data: new${tableNameSingularCapitalised}})
     return { ${tableNameSingular}: ${tableNameFirstChar} };
@@ -264,7 +264,7 @@ const generatePrismaDeleteMutation = (schema: Schema) => {
   return `export const delete${tableNameSingularCapitalised} = async (id: ${tableNameSingularCapitalised}Id) => {${getAuth}
   const { id: ${tableNameSingular}Id } = ${tableNameSingular}IdSchema.parse({ id });
   try {
-    const ${tableNameFirstChar} = await db.${tableNameSingular}.delete({ where: { id: ${tableNameSingular}Id${authForWhereClausePrisma(
+    const ${tableNameFirstChar} = await db.${tableNameSingular}.deleteMany({ where: { id: ${tableNameSingular}Id${authForWhereClausePrisma(
       belongsToUser
     )} }})
     return { ${tableNameSingular}: ${tableNameFirstChar} };


### PR DESCRIPTION
Updates  `generatePrismaDeleteMutation` & `generatePrismaUpdateMutation` to conditionally use `updateMany` and `deleteMany` in generated Prisma mutations for handling multiple `where` entries when `belongsToUser` is true

This should resolve #202 an issue related to multiple 'where' conditions [currently not being supported by Prisma](https://github.com/prisma/prisma/discussions/4185).
