### PR TITLE
Fix import for neon + removing fetchConnectionCache

### DIFF
--- a/src/commands/add/auth/lucia/index.ts
+++ b/src/commands/add/auth/lucia/index.ts
@@ -207,8 +207,8 @@ export type UsernameAndPassword = z.infer<typeof authenticationSchema>;
       encoding: "utf-8",
     });
     const contentsImportsUpdated = dbTsContents.replace(
-      "{ neon, neonConfig }",
-      "{ neon, neonConfig, Pool }"
+      "{ neon, neonConfig, NeonQueryFunction }",
+      "{ neon, neonConfig, NeonQueryFunction, Pool }"
     );
     const contentsWithPool = contentsImportsUpdated.concat(
       "\nexport const pool = new Pool({ connectionString: env.DATABASE_URL });"

--- a/src/commands/add/orm/drizzle/generators.ts
+++ b/src/commands/add/orm/drizzle/generators.ts
@@ -110,8 +110,8 @@ import { env } from "${formatFilePath(envMjs, {
         prefix: "alias",
       })}";
 
-neonConfig.fetchConnectionCache = true;
- 
+
+
 export const sql: NeonQueryFunction<boolean, boolean> = neon(env.DATABASE_URL);
 export const db = drizzle(sql);
 `;
@@ -282,8 +282,7 @@ import { migrate } from "drizzle-orm/neon-http/migrator";
 import { neon, neonConfig, NeonQueryFunction } from '@neondatabase/serverless';
 `;
       connectionLogic = `
-neonConfig.fetchConnectionCache = true;
- 
+
 const sql: NeonQueryFunction<boolean, boolean> = neon(env.DATABASE_URL);
 const db = drizzle(sql);
 `;


### PR DESCRIPTION
1) NeonQueryFunction was missing in import, so the original import could not be replaced correctly.

2) fetchConnectionCache config is now deprecated
![image](https://github.com/user-attachments/assets/ef00421c-8841-4538-b91d-7251b5122019)
