### PR TITLE
fix: updated shadcn cli command

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -167,7 +167,7 @@ export async function installShadcnUIComponents(
       componentsToInstall.push(component);
     }
   }
-  const baseArgs = ["shadcn-ui@latest", "add", ...componentsToInstall];
+  const baseArgs = ["shadcn@latest", "add", ...componentsToInstall];
   const installArgs =
     preferredPackageManager === "pnpm" ? ["dlx", ...baseArgs] : baseArgs;
 


### PR DESCRIPTION
Error: Shadcn components not installing
Reason: shadcn have updated cli command from shadcn-ui to shadcn