### PR TITLE
fix: Add issuer configuration to GitHub OAuth provider for RFC 9207 compatibility

### DIFF
--- a/src/commands/add/auth/next-auth/utils.ts
+++ b/src/commands/add/auth/next-auth/utils.ts
@@ -27,6 +27,7 @@ export const AuthProviders: ProviderConfig = {
     code: `GithubProvider({
       clientId: env.GITHUB_CLIENT_ID,
       clientSecret: env.GITHUB_CLIENT_SECRET,
+      issuer: "https://github.com/login/oauth",
     })`,
     website: "https://github.com/settings/apps",
   },


### PR DESCRIPTION
## Summary
GitHub silently enabled RFC 9207 (OAuth 2.0 Authorization Server Issuer Identification) between April 6-10, 2026, breaking GitHub OAuth sign-in in NextAuth v4 and other frameworks that use the openid-client library.

This fix adds the required 'issuer' field to the GithubProvider configuration to ensure proper RFC 9207 compliance.

## Changes
- Updated GitHub provider configuration in src/commands/add/auth/next-auth/utils.ts to include issuer: "https://github.com/login/oauth"

## References
- Langfuse Issue: https://github.com/langfuse/langfuse/issues/13091
- RFC 9207 Specification: https://datatracker.ietf.org/doc/html/rfc9207
